### PR TITLE
Add new 'Dimer RACs' function, get_descriptor_vector_dimers.

### DIFF
--- a/molSimplify/Informatics/RACassemble.py
+++ b/molSimplify/Informatics/RACassemble.py
@@ -126,6 +126,74 @@ def get_descriptor_vector(this_complex,custom_ligand_dict=False,ox_modifier=Fals
         return descriptor_names, descriptors
 
 
+## Gets the RACs of an octahedral complex without/without geo
+#  @param this_complex mol3D() we want RACs for
+#  @param custom_ligand_dict optional dict defining ligands (see below)
+#  @return descriptor_names updated names
+#  @return descriptors updated RACs
+def get_descriptor_vector_dimers(this_complex,custom_ligand_dict=False,custom_ligand_dict_legacy=False,ox_modifier=False):
+        descriptor_names = []
+        descriptors = []
+        ## misc descriptors
+        results_dictionary = generate_all_ligand_misc_dimers(this_complex,loud=False,custom_ligand_dict=custom_ligand_dict)
+        descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['result_ax1'],'misc','ax1')
+        descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['result_ax2'],'misc','ax2')
+        descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['result_ax3'],'misc','ax3')
+        
+        ## full ACs
+        results_dictionary = generate_full_complex_autocorrelations(this_complex,depth=3,loud=False,flag_name=False, modifier=ox_modifier)
+        descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['results'],'f','all')
+
+         ## ligand ACs
+        #print('get ligand ACs')
+        results_dictionary = generate_all_ligand_autocorrs_and_deltametrics_dimers(this_complex,depth=3,loud=True,name=False,
+                                                                                   flag_name=False,
+                                                                                   custom_ligand_dict=custom_ligand_dict)
+        descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['result_ax1_full'],'f','ax1')
+        descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['result_ax2_full'],'f','ax2')
+        descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['result_ax3_full'],'f','ax3')
+
+        descriptor_names, descriptors =  append_descriptors(descriptor_names, descriptors,
+                                                            results_dictionary['colnames'],results_dictionary['result_ax1_con'],'lc','ax1')
+        descriptor_names, descriptors =  append_descriptors(descriptor_names, descriptors,
+                                                            results_dictionary['colnames'],results_dictionary['result_ax2_con'],'lc','ax2')
+        descriptor_names, descriptors =  append_descriptors(descriptor_names, descriptors,
+                                                            results_dictionary['colnames'],results_dictionary['result_ax3_con'],'lc','ax3')
+        
+        #results_dictionary = generate_all_ligand_deltametrics(this_complex,depth=3,loud=False,name=False,custom_ligand_dict=custom_ligand_dict_legacy)
+        descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['result_delta_ax1_con'],'D_lc','ax1')
+        descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['result_delta_ax2_con'],'D_lc','ax2')
+        descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['result_delta_ax3_con'],'D_lc','ax3')
+        
+        ## metal ACs
+        #print('getting metal ACs')
+        results_dictionary = generate_metal_autocorrelations(this_complex,depth=3,loud=False, modifier=ox_modifier)
+        descriptor_names, descriptors =  append_descriptors(descriptor_names, descriptors,
+                                                            results_dictionary['colnames'],results_dictionary['results'],'mc','all')
+        results_dictionary = generate_metal_deltametrics(this_complex,depth=3,loud=False, modifier=ox_modifier)
+        descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['results'],'D_mc','all')
+        # ## ox-metal ACs, if ox available
+        if ox_modifier:
+            results_dictionary = generate_metal_ox_autocorrelations(ox_modifier, this_complex,depth=3,loud=False)
+            descriptor_names, descriptors =  append_descriptors(descriptor_names, descriptors,
+                                                            results_dictionary['colnames'],results_dictionary['results'],'mc','all')
+            results_dictionary = generate_metal_ox_deltametrics(ox_modifier,this_complex,depth=3,loud=False)
+            descriptor_names, descriptors = append_descriptors(descriptor_names, descriptors,
+                                                           results_dictionary['colnames'],results_dictionary['results'],'D_mc','all')    
+                                                           
+        return descriptor_names, descriptors
+
 ## utility to add one-hot encoded oxidation state
 ## and d-electron count to some descriptors
 #  @param descriptor_names RAC names, will be appended to

--- a/molSimplify/Informatics/misc_descriptors.py
+++ b/molSimplify/Informatics/misc_descriptors.py
@@ -31,21 +31,21 @@ def generate_all_ligand_misc(mol,loud,custom_ligand_dict=False):
                 eq_ligand_list = custom_ligand_dict["eq_ligand_list"]
                 ax_con_int_list = custom_ligand_dict["ax_con_int_list"]
                 eq_con_int_list = custom_ligand_dict["eq_con_int_list"]
-	## count ligands
-	n_ax = len(ax_ligand_list)
-	n_eq = len(eq_ligand_list)
-	## allocate
-	result_ax_dent = False
-	result_eq_dent = False
-	result_ax_maxdelen = False
-	result_eq_maxdelen = False
-	result_ax_ki = False
-	result_eq_ki = False
-	result_ax_tki = False
-	result_eq_tki = False
-	result_ax_charge = False
-	result_eq_charge = False
-	## loop over axial ligands
+        ## count ligands
+        n_ax = len(ax_ligand_list)
+        n_eq = len(eq_ligand_list)
+        ## allocate
+        result_ax_dent = False
+        result_eq_dent = False
+        result_ax_maxdelen = False
+        result_eq_maxdelen = False
+        result_ax_ki = False
+        result_eq_ki = False
+        result_ax_tki = False
+        result_eq_tki = False
+        result_ax_charge = False
+        result_eq_charge = False
+        ## loop over axial ligands
         if n_ax > 0:
                 for i in range(0,n_ax):
                         ax_ligand_list[i].mol.convert2OBMol()
@@ -69,7 +69,7 @@ def generate_all_ligand_misc(mol,loud,custom_ligand_dict=False):
                 result_ax_tki = np.divide(result_ax_tki,n_ax)
                 result_ax_charge = np.divide(result_ax_charge,n_ax) 
                 
-	## loop over eq ligands
+        ## loop over eq ligands
         if n_eq > 0:
                 for i in range(0,n_eq):
                         eq_ligand_list[i].mol.convert2OBMol()
@@ -92,21 +92,92 @@ def generate_all_ligand_misc(mol,loud,custom_ligand_dict=False):
                 result_eq_tki = np.divide(result_eq_tki,n_eq)
                 result_eq_charge = np.divide(result_eq_charge,n_eq) 
                 ## save the results        
-	result_ax.append(result_ax_dent)
-	result_ax.append(result_ax_maxdelen)
-	result_ax.append(result_ax_ki)
-	result_ax.append(result_ax_tki)
+        result_ax.append(result_ax_dent)
+        result_ax.append(result_ax_maxdelen)
+        result_ax.append(result_ax_ki)
+        result_ax.append(result_ax_tki)
         result_ax.append(result_ax_charge)
         
-	result_eq.append(result_eq_dent)
-	result_eq.append(result_eq_maxdelen)
-	result_eq.append(result_eq_ki)
-	result_eq.append(result_eq_tki)
+        result_eq.append(result_eq_dent)
+        result_eq.append(result_eq_maxdelen)
+        result_eq.append(result_eq_ki)
+        result_eq.append(result_eq_tki)
         result_eq.append(result_eq_charge)
         
-	results_dictionary={'colnames':colnames,'result_ax':result_ax,'result_eq':result_eq}
-	return  results_dictionary
+        results_dictionary={'colnames':colnames,'result_ax':result_ax,'result_eq':result_eq}
+        return  results_dictionary
 
+
+def generate_all_ligand_misc_dimers(mol,loud,custom_ligand_dict=False):
+        ## custom_ligand_dict.keys() must be ax1_ligands_list, ax2_ligand_list, ax3_ligand_list
+        ##                                    ax1_con_int_list , ax2_con_int_list, ax3_con_int_list
+        ## with types: ax_{i}_ligand_list list of mol3D
+        ##             ax_{i}_con_int_list list of list/tuple of int e.g,  [[1,2] [1,2]]
+        result_ax1 = list()
+        result_ax2 = list()
+        result_ax3 = list()
+        result_axs = [result_ax1, result_ax2, result_ax3]
+        colnames = ['dent','maxDEN','ki','tki','charge']
+        if not custom_ligand_dict:
+                raise ValueError('No custom_ligand_dict provided!')
+                #liglist, ligdents, ligcons = ligand_breakdown(mol)
+                #ax_ligand_list, eq_ligand_list, ax_natoms_list, eq_natoms_list, ax_con_int_list, eq_con_int_list, ax_con_list, eq_con_list, built_ligand_list = ligand_assign(
+                #    mol, liglist, ligdents, ligcons, loud, name=False)
+        else:
+                ax1_ligand_list = custom_ligand_dict["ax1_ligand_list"]
+                ax2_ligand_list = custom_ligand_dict["ax2_ligand_list"]
+                ax3_ligand_list = custom_ligand_dict["ax3_ligand_list"]
+                ax1_con_int_list = custom_ligand_dict["ax1_con_int_list"]
+                ax2_con_int_list = custom_ligand_dict["ax2_con_int_list"]
+                ax3_con_int_list = custom_ligand_dict["ax3_con_int_list"]
+                axligs = [ax1_ligand_list, ax2_ligand_list, ax3_ligand_list]
+                axcons = [ax1_con_int_list, ax2_con_int_list, ax3_con_int_list]
+                n_axs = [len(i) for i in axligs]
+        ## allocate
+        '''
+        result_ax_dent = False
+        result_eq_dent = False
+        result_ax_maxdelen = False
+        result_eq_maxdelen = False
+        result_ax_ki = False
+        result_eq_ki = False
+        result_ax_tki = False
+        result_eq_tki = False
+        result_ax_charge = False
+        result_eq_charge = False
+        '''
+        ## loop over axial ligands
+        assert all([i>0 for i in n_axs]), 'At least one axis has no ligands. # Ligands: %s' % n_axs
+        for ax_ligand_list, ax_con_int_list, n_ax, result_ax in zip(axligs, axcons, n_axs, result_axs):
+                for i in range(0,n_ax):
+                        ax_ligand_list[i].mol.convert2OBMol()
+                        if not (i==0):
+                                result_ax_dent += ax_ligand_list[i].dent
+                                result_ax_maxdelen += get_lig_EN(ax_ligand_list[i].mol,ax_con_int_list[i])
+                                result_ax_ki += kier(ax_ligand_list[i].mol)
+                                result_ax_tki += get_truncated_kier(ax_ligand_list[i].mol,ax_con_int_list[i])
+                                result_ax_charge += ax_ligand_list[i].mol.OBMol.GetTotalCharge()
+                        else:
+                                result_ax_dent = ax_ligand_list[i].dent
+                                result_ax_maxdelen = get_lig_EN(ax_ligand_list[i].mol,ax_con_int_list[i])
+                                result_ax_ki = kier(ax_ligand_list[i].mol)
+                                result_ax_tki = get_truncated_kier(ax_ligand_list[i].mol,ax_con_int_list[i])
+                                result_ax_charge = ax_ligand_list[i].mol.OBMol.GetTotalCharge()
+                ## average axial results
+                result_ax_dent = np.divide(result_ax_dent,n_ax)
+                result_ax_maxdelen = np.divide(result_ax_maxdelen,n_ax)
+                result_ax_ki = np.divide(result_ax_ki,n_ax)
+                result_ax_tki = np.divide(result_ax_tki,n_ax)
+                result_ax_charge = np.divide(result_ax_charge,n_ax) 
+                
+                result_ax.append(result_ax_dent)
+                result_ax.append(result_ax_maxdelen)
+                result_ax.append(result_ax_ki)
+                result_ax.append(result_ax_tki)
+                result_ax.append(result_ax_charge)
+        assert all([len(i)>0 for i in [result_ax1, result_ax2, result_ax3]]), 'Some results are empty.'
+        results_dictionary={'colnames':colnames,'result_ax1':result_ax1,'result_ax2':result_ax2,'result_ax3':result_ax3}
+        return results_dictionary
 
 def get_lig_EN(mol,connection_atoms):
         ## calculate the maximum abs electronegativity


### PR DESCRIPTION
This calculates RACs for each of the three axial pairs in an octahedral complex. The old RAC function, get_descriptor_vector, calculates RACs for one axial pair and and one set of equatorial ligands (i.e. an average over both of the other axial pairs). What were 'ax' and 'eq' are now 'ax1', 'ax2', and 'ax3' in this representation. This results in 77 additional features.