### PR TITLE
Remove most 'import *' statements and fix circular dependencies.

### DIFF
--- a/molSimplify/Classes/dft_obs.py
+++ b/molSimplify/Classes/dft_obs.py
@@ -5,11 +5,13 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from molSimplify.Classes.ligand import *
-from molSimplify.Classes.mol3D import *
-from molSimplify.Classes.atom3D import *
-from molSimplify.Informatics.autocorrelation import *
-from molSimplify.Informatics.misc_descriptors import *
+from molSimplify.Informatics.autocorrelation import (generate_all_ligand_autocorrelations,
+                                                     generate_all_ligand_deltametrics,
+                                                     generate_full_complex_autocorrelations,
+                                                     generate_metal_autocorrelations,
+                                                     generate_metal_deltametrics)
+from molSimplify.Informatics.misc_descriptors import (generate_all_ligand_misc)
+from molSimplify.Classes.mol3D import mol3D
 
 # DFT observations used to postprocess DFT results by measuring ligand properties
 

--- a/molSimplify/Classes/hessian_modify.py
+++ b/molSimplify/Classes/hessian_modify.py
@@ -4,7 +4,6 @@ import glob
 import os
 import re
 import numpy as np
-# from molSimplify.Classes.mol3D import *
 
 # partial hessian
 

--- a/molSimplify/Classes/mol3D.py
+++ b/molSimplify/Classes/mol3D.py
@@ -5,11 +5,20 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from molSimplify.Scripts.geometry import distance, connectivity_match, vecangle, rotation_params, rotate_around_axis
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import xml.etree.ElementTree as ET
+from math import sqrt
+import numpy as np
+import openbabel
+
 from molSimplify.Classes.atom3D import atom3D
 from molSimplify.Classes.globalvars import globalvars
-import numpy as np
-
+from molSimplify.Scripts.geometry import distance, connectivity_match, vecangle, rotation_params, rotate_around_axis
 from molSimplify.Scripts.rmsd import rigorous_rmsd
 
 try:

--- a/molSimplify/Classes/mol3D.py
+++ b/molSimplify/Classes/mol3D.py
@@ -7,6 +7,7 @@
 
 from molSimplify.Scripts.geometry import distance, connectivity_match, vecangle, rotation_params, rotate_around_axis
 from molSimplify.Classes.atom3D import atom3D
+from molSimplify.Classes.globalvars import globalvars
 import numpy as np
 
 from molSimplify.Scripts.rmsd import rigorous_rmsd

--- a/molSimplify/Classes/mol3D.py
+++ b/molSimplify/Classes/mol3D.py
@@ -5,25 +5,10 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from math import sqrt
-import numpy as np
+from molSimplify.Scripts.geometry import distance, connectivity_match, vecangle, rotation_params, rotate_around_axis
 from molSimplify.Classes.atom3D import atom3D
-from molSimplify.Classes.globalvars import globalvars
-import openbabel
-import sys
-import time
-import os
-import subprocess
-import random
-import shutil
-import unicodedata
-import inspect
-import tempfile
-import re
-from pkg_resources import resource_filename, Requirement
-import xml.etree.ElementTree as ET
-from molSimplify.Scripts.geometry import vecangle, distance, kabsch, rotation_params, rotate_around_axis, \
-    connectivity_match
+import numpy as np
+
 from molSimplify.Scripts.rmsd import rigorous_rmsd
 
 try:
@@ -2724,7 +2709,6 @@ class mol3D:
                        check_whole=False, angle_ref=False):
         from molSimplify.Informatics.graph_analyze import obtain_truncation_metal
         from molSimplify.Classes.ligand import ligand_breakdown  # , ligand_assign
-        from molSimplify.Classes.ligand import ligand_assign_consistent as ligand_assign
         flag_match = True
         self.my_mol_trunc = mol3D()
         self.my_mol_trunc.copymol3D(self)
@@ -2841,7 +2825,6 @@ class mol3D:
                         flag_lbd=True, debug=False, depth=3,
                         BondedOct=False, angle_ref=False):
         from molSimplify.Scripts.oct_check_mols import readfromtxt
-        from molSimplify.Informatics.graph_analyze import obtain_truncation_metal
         _, _, flag_match = self.match_lig_list(init_mol,
                                                catoms_arr=catoms_arr,
                                                flag_loose=flag_loose,

--- a/molSimplify/Classes/partialcharges.py
+++ b/molSimplify/Classes/partialcharges.py
@@ -1,6 +1,7 @@
-from molSimplify.Classes.mol3D import *
 import numpy as np
-import glob
+
+from molSimplify.Classes.mol3D import (distance,
+                                       mol3D)
 
 # xyzf = '/Users/tzuhsiungyang/Downloads/cuacetate1k2acetate1o-pyridylphenyl1_0_1_RIJCOSX-B3LYP-D3_BS_TS-ar-carboxylation.numfreq.xyz'
 

--- a/molSimplify/Informatics/autocorrelation.py
+++ b/molSimplify/Informatics/autocorrelation.py
@@ -1,16 +1,7 @@
-import glob
-import string
-import sys
-import os
 import numpy as np
-import math
-import random
-from molSimplify.Scripts.geometry import *
-from molSimplify.Classes.atom3D import *
-from molSimplify.Classes.globalvars import globalvars
-from molSimplify.Classes.mol3D import *
-from molSimplify.Classes.ligand import *
 from molSimplify.Classes.ligand import ligand_breakdown, ligand_assign
+from molSimplify.Classes.mol3D import (distance)
+from molSimplify.Classes.globalvars import globalvars
 
 ########### UNIT CONVERSION
 HF_to_Kcal_mol = 627.503

--- a/molSimplify/Informatics/clean_autocorrelation.py
+++ b/molSimplify/Informatics/clean_autocorrelation.py
@@ -1,16 +1,7 @@
-import glob
-import string
-import sys
-import os
 import numpy as np
-import math
-import random
-from molSimplify.Scripts.geometry import *
-from molSimplify.Classes.atom3D import *
 from molSimplify.Classes.globalvars import globalvars
-from molSimplify.Classes.mol3D import *
-from molSimplify.Classes.ligand import *
 from molSimplify.Classes.ligand import ligand_breakdown, ligand_assign
+from molSimplify.Classes.mol3D import distance
 
 ########### UNIT CONVERSION
 HF_to_Kcal_mol = 627.503

--- a/molSimplify/Informatics/decoration_manager.py
+++ b/molSimplify/Informatics/decoration_manager.py
@@ -4,22 +4,31 @@
 
 
 # import standard modules
-import os, sys
-from pkg_resources import resource_filename, Requirement
-import openbabel, random, itertools
-from numpy import log, arccos, cross, dot, pi
 
 # molS modules
-from molSimplify.Classes.globalvars import *
-from molSimplify.Classes.mol3D import *
-from molSimplify.Scripts.geometry import *
-from molSimplify.Scripts.molSimplify_io import *
-import molSimplify.Scripts.structgen ## this is needed for circlular 
-                                     ## FF dependence
+from molSimplify.Classes.mol3D import (distance,
+                                       mol3D)
+from molSimplify.Scripts.geometry import (checkcolinear,
+                                          distance,
+                                          norm,
+                                          rotate_around_axis,
+                                          rotation_params,
+                                          vecangle,
+                                          vecdiff)
+from molSimplify.Scripts.molSimplify_io import (getlicores,
+                                                lig_load)
+
+## FF dependence
 ##########################################
 ####### ligand decoration function #######
-##########################################    
+##########################################
+
+
+
 def decorate_ligand(args,ligand_to_decorate,decoration,decoration_index):
+    # structgen depends on decoration_manager, and decoration_manager depends on structgen.ffopt
+    # Thus, this import needs to be placed here to avoid a circular dependence
+    from molSimplify.Scripts.structgen import ffopt
     # INPUT
     #   - args: placeholder for input arguments
     #   - ligand_to_decorate: mol3D ligand
@@ -183,7 +192,7 @@ def decorate_ligand(args,ligand_to_decorate,decoration,decoration_index):
             print('************')
     
     merged_ligand.convert2OBMol()
-    merged_ligand,emsg = molSimplify.Scripts.structgen.ffopt('MMFF94',merged_ligand,[],0,[],False,[],100)
+    merged_ligand,emsg = ffopt('MMFF94',merged_ligand,[],0,[],False,[],100)
     BO_mat = merged_ligand.populateBOMatrix()
     if args.debug:
         merged_ligand.writexyz('merged_relaxed.xyz')

--- a/molSimplify/Informatics/geo_analyze.py
+++ b/molSimplify/Informatics/geo_analyze.py
@@ -7,9 +7,8 @@
 ########     geometries for octahedral    ################
 ################      TM complexs          ###############
 ##########################################################
-from molSimplify.Classes.ligand import *
 from molSimplify.Classes.ligand import ligand_breakdown, ligand_assign
-from molSimplify.Classes.mol3D import *
+from molSimplify.Classes.mol3D import distance
 
 def getOctBondDistances(mol):
     ## This function gets

--- a/molSimplify/Informatics/graph_analyze.py
+++ b/molSimplify/Informatics/graph_analyze.py
@@ -7,11 +7,9 @@
 ########   in mol3D form to a truncated graph #############
 ##########################################################
 # import modules
-import numpy as np
-from molSimplify.Scripts.geometry import *
-from molSimplify.Classes.atom3D import *
 from molSimplify.Classes.globalvars import globalvars
-from molSimplify.Classes.mol3D import *
+from molSimplify.Classes.mol3D import mol3D
+import numpy as np
 
 
 def obtain_truncation(mol, con_atoms, hops):

--- a/molSimplify/Informatics/misc_descriptors.py
+++ b/molSimplify/Informatics/misc_descriptors.py
@@ -1,20 +1,10 @@
-import glob
-import string
-import sys
-import os
-import numpy as np
-import math
-import random
-import string
-import numpy
-from molSimplify.Scripts.geometry import *
 #from molSimplify.Scripts.nn_prep import *
-from molSimplify.Classes.atom3D import *
-from molSimplify.Classes.globalvars import globalvars
-from molSimplify.Classes.mol3D import*
-from molSimplify.Classes.ligand import *
 from molSimplify.Classes.ligand import ligand_breakdown, ligand_assign
-from molSimplify.Informatics.graph_analyze import *
+from molSimplify.Informatics.graph_analyze import (get_lig_EN,
+                                                   get_truncated_kier,
+                                                   kier)
+from molSimplify.Classes.globalvars import globalvars
+import numpy as np
 
 
 def generate_all_ligand_misc(mol, loud, custom_ligand_dict=False, force_legacy=False):

--- a/molSimplify/Informatics/misc_descriptors.py
+++ b/molSimplify/Informatics/misc_descriptors.py
@@ -1,4 +1,3 @@
-#from molSimplify.Scripts.nn_prep import *
 from molSimplify.Classes.ligand import ligand_breakdown, ligand_assign
 from molSimplify.Informatics.graph_analyze import (get_lig_EN,
                                                    get_truncated_kier,

--- a/molSimplify/Informatics/partialcharges.py
+++ b/molSimplify/Informatics/partialcharges.py
@@ -1,7 +1,6 @@
-from molSimplify.Classes.mol3D import *
-from molSimplify.Scripts.geometry import rotation_params
 import numpy as np
-import glob
+
+from molSimplify.Classes.mol3D import (distance)
 
 def fpriority(mol):
     # setting up variables

--- a/molSimplify/Scripts/cellbuilder.py
+++ b/molSimplify/Scripts/cellbuilder.py
@@ -6,23 +6,45 @@
 #  Dpt of Chemical Engineering, MIT
 
 import os
-import sys
-import copy
-import glob
-import re
-import math
 import random
-import string
+import copy
 import numpy
-from math import pi
-from scipy.spatial import Delaunay, ConvexHull
-from molSimplify.Scripts.geometry import *
-from molSimplify.Classes.atom3D import *
-from molSimplify.Classes.mol3D import*
+from math import sqrt
+
+from scipy.spatial import Delaunay
+from molSimplify.Classes.atom3D import atom3D
+from molSimplify.Classes.mol3D import (rotate_around_axis,
+                                       rotation_params,
+                                       vecangle,
+                                       distance,
+                                       mol3D)
 from molSimplify.Classes.globalvars import globalvars
-from operator import add
-from molSimplify.Scripts.periodic_QE import *
-from molSimplify.Scripts.cellbuilder_tools import *
+from molSimplify.Scripts.cellbuilder_tools import (cell_ffopt,
+                                                   center_of_sym,
+                                                   check_top_layer_correct,
+                                                   closest_torus_point,
+                                                   distance_2d_torus,
+                                                   evaluate_basis_coefficients,
+                                                   find_all_surface_atoms,
+                                                   find_extents,
+                                                   find_extents_cv,
+                                                   freeze_bottom_n_layers,
+                                                   get_basis_coefficients,
+                                                   import_from_cif,
+                                                   mdistance,
+                                                   normalize_vector,
+                                                   periodic_mindist,
+                                                   periodic_selfdist,
+                                                   shave_surface_layer,
+                                                   shave_under_layer,
+                                                   threshold_basis,
+                                                   xgcd,
+                                                   zero_z)
+from molSimplify.Scripts.geometry import (PointRotateAxis,
+                                          checkcolinear,
+                                          vecdiff)
+from molSimplify.Scripts.periodic_QE import (write_periodic_mol3d_to_qe)
+
 
 ###############################
 
@@ -795,7 +817,7 @@ def molecule_placement_supervisor(super_cell, super_cell_vector, target_molecule
         align_axis = False
     if control_angle and not align_ind:
         print('align_ind not found, even though control_angle is on. Disabling controlled rotation')
-        control_angle = false
+        control_angle = False
     if (method == 'alignpair') and not (surface_atom_type or surface_atom_ind):
         print('Must provide surface binding atom type to use alignpair')
         print(' using centered placemented instead')

--- a/molSimplify/Scripts/cellbuilder_tools.py
+++ b/molSimplify/Scripts/cellbuilder_tools.py
@@ -5,25 +5,18 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-import os
-import sys
-import copy
-import glob
 import re
-import math
-import random
-import string
+
 import numpy
 import openbabel
-from math import pi
-#from scipy.spatial import Delaunay, ConvexHull
-#import networkx as nx
-from molSimplify.Scripts.geometry import *
-from molSimplify.Classes.atom3D import *
-from molSimplify.Classes.mol3D import*
-from molSimplify.Classes.globalvars import globalvars
-from operator import add
-from molSimplify.Scripts.periodic_QE import *
+import copy
+from math import sqrt, pi
+from molSimplify.Classes.globalvars import (globalvars)
+from molSimplify.Classes.mol3D import (distance,
+                                       mol3D)
+# from scipy.spatial import Delaunay, ConvexHull
+# import networkx as nx
+
 
 ###############################
 # Main cell FF opt routine

--- a/molSimplify/Scripts/chains.py
+++ b/molSimplify/Scripts/chains.py
@@ -5,22 +5,18 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-import sys
-import os
-import random
-import shutil
-import inspect
-import argparse
-import openbabel
-from molSimplify.Scripts.rungen import *
-from molSimplify.Scripts.molSimplify_io import *
-from molSimplify.Scripts.inparse import *
-from molSimplify.Classes.atom3D import *
-from molSimplify.Classes.mol3D import*
-from molSimplify.Classes.globalvars import globalvars
 from math import sqrt
-from math import floor
+
 import numpy as np
+
+from molSimplify.Classes.mol3D import (distance,
+                                       mol3D)
+from molSimplify.Scripts.geometry import (rotate_around_axis,
+                                          rotation_params,
+                                          vecangle,
+                                          vecdiff)
+from molSimplify.Scripts.rungen import (ffopt)
+import numpy
 
 
 def mdistance(r1, r2):

--- a/molSimplify/Scripts/chains.py
+++ b/molSimplify/Scripts/chains.py
@@ -15,7 +15,7 @@ from molSimplify.Scripts.geometry import (rotate_around_axis,
                                           rotation_params,
                                           vecangle,
                                           vecdiff)
-from molSimplify.Scripts.rungen import (ffopt)
+from molSimplify.Scripts.structgen import (ffopt)
 import numpy
 
 

--- a/molSimplify/Scripts/dbinteract.py
+++ b/molSimplify/Scripts/dbinteract.py
@@ -6,16 +6,21 @@
 #  Dpt of Chemical Engineering, MIT
 
 
-from molSimplify.Scripts.geometry import *
-from molSimplify.Scripts.molSimplify_io import *
-from molSimplify.Classes.globalvars import *
 import os
-import sys
 import re
-import string
 import shutil
-import time
+import string
+try:
+    import pymol
+except:
+    pass
 import openbabel
+
+from molSimplify.Classes.globalvars import (amassdict,
+                                            glob,
+                                            globalvars,
+                                            mybash)
+from molSimplify.Scripts.molSimplify_io import (plugin_defs)
 
 
 def float_from_str(txt):
@@ -436,7 +441,6 @@ def dbsearch(rundir, args, globs):
 
     obab = 'obabel'
     if args.gui:
-        from molSimplify.Classes.mWidgets import mQDialogErr
         from molSimplify.Classes.mWidgets import mQDialogWarn
         from molSimplify.Classes.mWidgets import mQDialogInf
     ### in any case do similarity search over indexed db ###

--- a/molSimplify/Scripts/distgeom.py
+++ b/molSimplify/Scripts/distgeom.py
@@ -12,15 +12,22 @@
 #
 #  [2] G. Crippen and T. F. Havel, "Distance Geometry and Molecular Conformation", in Chemometrics Research Studies Series, Wiley (1988)
 
-from molSimplify.Scripts.geometry import *
-from molSimplify.Scripts.molSimplify_io import *
-from molSimplify.Classes.globalvars import *
-from molSimplify.Classes.atom3D import atom3D
-import os
-import sys
-import openbabel
 import numpy as np
+import numpy
+import openbabel
 from scipy import optimize
+from math import sqrt, cos
+
+from molSimplify.Classes.atom3D import atom3D
+from molSimplify.Classes.mol3D import mol3D
+from molSimplify.Classes.globalvars import (vdwrad)
+from molSimplify.Scripts.geometry import (distance,
+                                          norm,
+                                          vecangle,
+                                          vecdiff)
+from molSimplify.Scripts.molSimplify_io import (lig_load,
+                                                loadcoord)
+
 
 # Applies the cosine rule to get the length of AC given lengths of AB, BC and angle ABC
 #  @param AB Length of AB

--- a/molSimplify/Scripts/findcorrelations.py
+++ b/molSimplify/Scripts/findcorrelations.py
@@ -7,42 +7,27 @@
 
 import os
 import sys
-import copy
-import glob
-import re
-import math
-import random
-import string
-import numpy
-from math import pi
-from molSimplify.Scripts.geometry import *
-from molSimplify.Classes.atom3D import *
-from molSimplify.Classes.mol3D import*
-from molSimplify.Classes.ligand import*
-from molSimplify.Classes.dft_obs import*
-from molSimplify.Classes.globalvars import globalvars
-from molSimplify.Informatics.graph_analyze import *
-from molSimplify.Informatics.autocorrelation import *
-from molSimplify.Informatics.misc_descriptors import *
+import numpy as np
+from molSimplify.Classes.dft_obs import (dft_observation)
+from sklearn import linear_model, preprocessing, metrics, feature_selection, model_selection
 
-
-def test_skl():
-    valid = ok
-    try:
-        from sklearn import linear_model, preprocessing, metrics, feature_selection, model_selection
-    except:
-        valid = False
-    return valid
+# def test_skl():
+#     valid = 'ok'
+#     try:
+#         from sklearn import linear_model, preprocessing, metrics, feature_selection, model_selection
+#     except:
+#         valid = False
+#     return valid
 
 
 def analysis_supervisor(args, rootdir):
     status = True
     print('looking for scikit-learn')
-    if test_skl():
-        from sklearn import linear_model, preprocessing, metrics, feature_selection, model_selection
-    else:
-        print("Error, scikit-learn not loadable")
-        status = False
+    # if test_skl():
+    #     pass
+    # else:
+    #     print("Error, scikit-learn not loadable")
+    #     status = False
     if not args.correlate:
         print("Error, correlation path not given")
         status = False
@@ -61,7 +46,7 @@ def analysis_supervisor(args, rootdir):
     if args.simple:
         print('using simple autocorrelation descriptors only')
     if args.max_descriptors:
-        print(('using a max of '+str(max_descriptors)+' only'))
+        print(('using a max of '+str(args.max_descriptors)+' only'))
     res = correlation_supervisor(
         args.correlate, rootdir, args.simple, args.lig_only, args.max_descriptors)
 

--- a/molSimplify/Scripts/generator.py
+++ b/molSimplify/Scripts/generator.py
@@ -25,27 +25,25 @@
     along with molSimplify. If not, see http://www.gnu.org/licenses/.
 '''
 
-import sys
 import os
-import random
-import shutil
-import inspect
+import sys
+import glob
 import argparse
-import openbabel
-from molSimplify.Scripts.rungen import *
-from molSimplify.Scripts.molSimplify_io import *
-from molSimplify.Scripts.inparse import *
-from molSimplify.Scripts.dbinteract import *
-from molSimplify.Scripts.postproc import *
-from molSimplify.Scripts.cellbuilder import*
-from molSimplify.Scripts.chains import*
-from molSimplify.Scripts.findcorrelations import*
-from molSimplify.Scripts.addtodb import*
-from molSimplify.Classes.globalvars import *
-from molSimplify.Classes.mol3D import mol3D
-from molSimplify.Classes.atom3D import atom3D
-from math import sqrt
-from math import floor
+import copy
+from molSimplify.Classes.globalvars import (globalvars)
+from molSimplify.Scripts.addtodb import (addtoldb,
+                                         loadcdxml)
+from molSimplify.Scripts.cellbuilder import (slab_module_supervisor)
+from molSimplify.Scripts.chains import (chain_builder_supervisor)
+from molSimplify.Scripts.dbinteract import (dbsearch)
+from molSimplify.Scripts.findcorrelations import (analysis_supervisor)
+from molSimplify.Scripts.inparse import (checkinput,
+                                         cleaninput,
+                                         parseall,
+                                         parseinputfile)
+from molSimplify.Scripts.postproc import (postproc)
+from molSimplify.Scripts.rungen import (constrgen,
+                                        multigenruns)
 
 
 # Coordinates subroutines

--- a/molSimplify/Scripts/grabguivars.py
+++ b/molSimplify/Scripts/grabguivars.py
@@ -5,13 +5,9 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-import glob
-import os
 import re
-import argparse
-import sys
 import time
-from molSimplify.Scripts.molSimplify_io import *
+from molSimplify.Classes.globalvars import globalvars
 
 # Check true or false
 #  @param arg String to be checked

--- a/molSimplify/Scripts/inparse.py
+++ b/molSimplify/Scripts/inparse.py
@@ -5,17 +5,25 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-import glob
+import argparse
 import os
 import re
-import argparse
-import sys
-import ast
-import json
+
 import yaml
-from molSimplify.Scripts.molSimplify_io import *
-from molSimplify.Classes.globalvars import *
-from pkg_resources import resource_filename, Requirement
+
+from molSimplify.Classes.globalvars import (defaultspins,
+                                            elementsbynum,
+                                            globalvars,
+                                            metals_conv,
+                                            romans,
+                                            mtlsdlist)
+from molSimplify.Scripts.molSimplify_io import (getbinds,
+                                                getcores,
+                                                getgeoms,
+                                                getlicores,
+                                                getslicores,
+                                                printgeoms,
+                                                substr_load)
 
 
 # Checks input for correctness and uses defaults otherwise
@@ -127,7 +135,7 @@ def checkinput(args, calctype="base"):
             # default ligand if none given
             if not args.lig and not args.rgen:
                 if args.gui:
-                    from Classes.mWidgets import mQDialogWarn
+                    from molSimplify.Classes.mWidgets import mQDialogWarn
                     qqb = mQDialogWarn('Warning', 'You specified no ligands.')
                     qqb.setParent(args.gui.wmain)
                 else:
@@ -208,7 +216,7 @@ def checkinput(args, calctype="base"):
             # check ligands
             if not args.lig and not args.rgen:
                 if args.gui:
-                    from Classes.mWidgets import mQDialogWarn
+                    from molSimplify.Classes.mWidgets import mQDialogWarn
                     qqb = mQDialogWarn('Warning', 'You specified no ligands.')
                     qqb.setParent(args.gui.wmain)
                 else:

--- a/molSimplify/Scripts/io.py
+++ b/molSimplify/Scripts/io.py
@@ -5,19 +5,22 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
+import copy
+import random
+import re
+import shutil
 import glob
 import os
-import shutil
-import re
-import argparse
-import sys
-import random
+import time
+
+
 import openbabel
-import copy
-from molSimplify.Classes.mol3D import *
-from molSimplify.Classes.globalvars import *
-from molSimplify.Classes.mol3D import mol3D
 from pkg_resources import resource_filename, Requirement
+
+from molSimplify.Classes.globalvars import (globalvars,
+                                            romans)
+from molSimplify.Classes.mol3D import mol3D
+
 
 # Print available geometries
 

--- a/molSimplify/Scripts/krr_prep.py
+++ b/molSimplify/Scripts/krr_prep.py
@@ -5,26 +5,39 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from molSimplify.Classes import *
-from molSimplify.Informatics.autocorrelation import *
-from molSimplify.Informatics.graph_analyze import *
-from molSimplify.Informatics.partialcharges import *
-from molSimplify.Classes.mol3D import *
-from molSimplify.Classes.globalvars import *
-from sklearn.model_selection import train_test_split, GridSearchCV, LeaveOneOut
-from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor
-from sklearn.metrics import mean_absolute_error
-from sklearn.kernel_ridge import KernelRidge
-from sklearn.multioutput import MultiOutputRegressor
-from math import exp
-import numpy as np
-import csv
-import glob
-import os
 import copy
+import csv
+import os
 import pickle
+from math import exp
+import matplotlib.pyplot as plt
+import matplotlib.ticker as ticker
+import pandas as pd
+from pkg_resources import (resource_filename, Requirement)
+
+
+import numpy as np
+from sklearn.ensemble import RandomForestRegressor, GradientBoostingRegressor
+from sklearn.kernel_ridge import KernelRidge
+from sklearn.metrics import mean_absolute_error
+from sklearn.model_selection import train_test_split, GridSearchCV, LeaveOneOut
+from sklearn.multioutput import MultiOutputRegressor
+
+from molSimplify.Classes.globalvars import (globalvars)
+from molSimplify.Classes.mol3D import (distance,
+                                       vecangle)
+from molSimplify.Informatics.autocorrelation import (atom_only_autocorrelation,
+                                                     atom_only_deltametric,
+                                                     atom_only_ratiometric,
+                                                     atom_only_summetric,
+                                                     generate_atomonly_autocorrelations,
+                                                     generate_atomonly_deltametrics)
+from molSimplify.Informatics.partialcharges import (ffeatures)
+
 # import matplotlib.pyplot as plt
 # import matplotlib.ticker as ticker
+from molSimplify.Scripts.geometry import vecdiff
+
 np.seterr(divide='ignore')
 
 csvf = '/Users/tzuhsiungyang/Dropbox (MIT)/Work at the Kulik group/ts_build/Data/xyzf_optts/selected_xyzfs/label_1distance_descs_atRACs.csv'

--- a/molSimplify/Scripts/molSimplify_io.py
+++ b/molSimplify/Scripts/molSimplify_io.py
@@ -5,19 +5,21 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
+import copy
+import random
+import re
+import shutil
 import glob
 import os
-import shutil
-import re
-import argparse
-import sys
-import random
+import time
+
 import openbabel
-import copy
-from molSimplify.Classes.mol3D import *
-from molSimplify.Classes.globalvars import *
-from molSimplify.Classes.mol3D import mol3D
 from pkg_resources import resource_filename, Requirement
+
+from molSimplify.Classes.globalvars import (globalvars,
+                                            romans)
+from molSimplify.Classes.mol3D import mol3D
+
 
 # Print available geometries
 

--- a/molSimplify/Scripts/namegen.py
+++ b/molSimplify/Scripts/namegen.py
@@ -5,15 +5,6 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from .structgen import *
-from molSimplify.Scripts.molSimplify_io import *
-import argparse
-import sys
-import os
-import shutil
-import itertools
-import random
-
 # Generates name for complex given core and ligands
 #  @param core mol3D of core
 #  @param ligs List of ligand names

--- a/molSimplify/Scripts/nn_prep.py
+++ b/molSimplify/Scripts/nn_prep.py
@@ -5,8 +5,8 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from molSimplify.Informatics.decoration_manager import (decorate_ligand,
-                                                        lig_load)
+from molSimplify.Scripts.molSimplify_io import (lig_load)
+from molSimplify.Informatics.decoration_manager import (decorate_ligand)
 from molSimplify.Informatics.graph_analyze import (get_lig_EN,
                                                    get_truncated_kier,
                                                    kier,

--- a/molSimplify/Scripts/nn_prep.py
+++ b/molSimplify/Scripts/nn_prep.py
@@ -5,14 +5,17 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from molSimplify.Scripts.geometry import *
-from molSimplify.Scripts.molSimplify_io import *
-from molSimplify.Informatics.decoration_manager import*
-from molSimplify.Classes.globalvars import *
-from molSimplify.Informatics.graph_analyze import *
-from molSimplify.python_nn.ANN import *
-import numpy
-import openbabel
+from molSimplify.Informatics.decoration_manager import (decorate_ligand,
+                                                        lig_load)
+from molSimplify.Informatics.graph_analyze import (get_lig_EN,
+                                                   get_truncated_kier,
+                                                   kier,
+                                                   obtain_truncation)
+from molSimplify.python_nn.ANN import (find_eu_dist,
+                                       simple_hs_ann,
+                                       simple_ls_ann,
+                                       simple_slope_ann,
+                                       simple_splitting_ann)
 
 
 def get_bond_order(OBMol, connection_atoms, mol):

--- a/molSimplify/Scripts/oct_check_mols.py
+++ b/molSimplify/Scripts/oct_check_mols.py
@@ -1,19 +1,19 @@
-from molSimplify.Classes.mol3D import *
-import glob
+import copy
 import os
-import time
 import re
 import sys
-import copy
+import time
 import numpy as np
-from molSimplify.Classes.globalvars import globalvars
-from molSimplify.Classes.ligand import *
-from molSimplify.Classes.ligand import ligand_breakdown, ligand_assign
-from molSimplify.Scripts.geometry import vecangle, distance, kabsch
-from molSimplify.Informatics.graph_analyze import obtain_truncation_metal
-from molSimplify.Classes.atom3D import *
+
+from molSimplify.Classes.atom3D import (atom3D,
+                                        globalvars)
 from molSimplify.Classes.globalvars import dict_oct_check_loose, dict_oct_check_st, dict_oneempty_check_st, \
-    dict_oneempty_check_loose, oct_angle_ref, oneempty_angle_ref
+    oct_angle_ref, oneempty_angle_ref
+from molSimplify.Classes.ligand import ligand_breakdown
+from molSimplify.Classes.ligand import (mol3D)
+from molSimplify.Classes.mol3D import (distance)
+from molSimplify.Informatics.graph_analyze import obtain_truncation_metal
+from molSimplify.Scripts.geometry import vecangle, distance, kabsch
 
 
 # from openpyxl import load_workbook

--- a/molSimplify/Scripts/periodic_QE.py
+++ b/molSimplify/Scripts/periodic_QE.py
@@ -5,20 +5,8 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-import os
-import sys
-import glob
-import re
-import math
-import random
-import string
-import numpy
-from math import pi
-from molSimplify.Scripts.geometry import *
-from molSimplify.Classes.atom3D import *
-from molSimplify.Classes.mol3D import*
 from molSimplify.Classes.globalvars import globalvars
-from operator import add
+
 
 ###############################
 

--- a/molSimplify/Scripts/postmold.py
+++ b/molSimplify/Scripts/postmold.py
@@ -5,13 +5,12 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-import os
-import sys
-import subprocess
-import time
 import re
-from molSimplify.Scripts.postparse import *
-from molSimplify.Classes.globalvars import *
+import os
+
+from molSimplify.Classes.globalvars import (mybash)
+from molSimplify.Scripts.postparse import (find_between)
+
 
 # Class for atoms containing molden file properties
 

--- a/molSimplify/Scripts/postmwfn.py
+++ b/molSimplify/Scripts/postmwfn.py
@@ -5,14 +5,16 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-import os
-import sys
-import subprocess
-import time
 import math
-import re
+import glob
+import os
+
 from numpy import cross, dot
-from molSimplify.Classes.globalvars import *
+from math import sqrt
+
+from molSimplify.Classes.globalvars import (globalvars,
+                                            mybash)
+
 
 # Gets distance between points
 #  @param R1 Point 1

--- a/molSimplify/Scripts/postparse.py
+++ b/molSimplify/Scripts/postparse.py
@@ -5,11 +5,9 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-import os
-import sys
-import subprocess
 import time
-from molSimplify.Classes.globalvars import *
+import os
+
 
 # Gets subset of string between two substrings
 #  @param s String to be split

--- a/molSimplify/Scripts/postproc.py
+++ b/molSimplify/Scripts/postproc.py
@@ -5,17 +5,22 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from molSimplify.Classes.globalvars import *
-from molSimplify.Scripts.postparse import *
-from molSimplify.Scripts.postmold import *
-from molSimplify.Scripts.postmwfn import *
-import os
-import sys
 import glob
-import subprocess
-import time
-import math
+import os
 import shutil
+import time
+
+from molSimplify.Scripts.postmold import (moldpost)
+from molSimplify.Scripts.postmwfn import (deloc,
+                                          getcharges,
+                                          getcubes,
+                                          getwfnprops,
+                                          globalvars,
+                                          mybash)
+from molSimplify.Scripts.postparse import (gampost,
+                                           nbopost,
+                                           terapost)
+
 
 # Check if multiwfn exists
 #  @param mdir Multiwfn directory
@@ -37,8 +42,7 @@ def checkmultiwfn(mdir):
 def postproc(rundir, args, globs):
     globs = globalvars()
     if args.gui:
-        from Classes.mWidgets import mQDialogErr
-        from Classes.mWidgets import mQDialogInf
+        from molSimplify.Classes.mWidgets import mQDialogInf
         choice = mQDialogInf(
             'Post processing', 'Parsing the results will take a while..Please be patient. Start?')
         choice.setParent(args.gui.pWindow)

--- a/molSimplify/Scripts/qcgen.py
+++ b/molSimplify/Scripts/qcgen.py
@@ -5,14 +5,13 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from molSimplify.Classes.globalvars import *
-import glob
-import sys
-import os
 import shutil
+import os
+
+from molSimplify.Classes.globalvars import (globalvars,
+                                            romans)
 from molSimplify.Classes.mol3D import mol3D
-from molSimplify.Classes.atom3D import atom3D
-from molSimplify.Classes.globalvars import *
+
 
 # Generate multiple terachem runs if multiple methods requested
 #  @param args Namespace of arguments

--- a/molSimplify/Scripts/rungen.py
+++ b/molSimplify/Scripts/rungen.py
@@ -5,22 +5,30 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from .structgen import *
-from molSimplify.Scripts.molSimplify_io import *
-from molSimplify.Scripts.jobgen import *
-from molSimplify.Scripts.qcgen import *
-from molSimplify.Scripts.isomers import generateisomers
-# from molSimplify.Scripts.tsgen import *
-from molSimplify.Classes.rundiag import *
-import argparse
-import sys
-import os
-import shutil
 import itertools
+import os
 import random
+import shutil
+import sys
 from collections import Counter
-from pkg_resources import resource_filename, Requirement
-import openbabel
+import glob
+
+from molSimplify.Scripts.isomers import generateisomers
+from molSimplify.Scripts.jobgen import (sgejobgen,
+                                        slurmjobgen)
+from molSimplify.Scripts.molSimplify_io import (core_load,
+                                                getlicores,
+                                                lig_load,
+                                                name_complex,
+                                                name_ts_complex,
+                                                substr_load)
+from molSimplify.Scripts.qcgen import (mlpgen,
+                                       multigamgen,
+                                       multimolcgen,
+                                       multiogen,
+                                       multiqgen,
+                                       multitcgen)
+from molSimplify.Scripts.structgen import (structgen)
 
 ###################################################################
 ### define input for cross-compatibility between python 2 and 3 ###

--- a/molSimplify/Scripts/rungen.py
+++ b/molSimplify/Scripts/rungen.py
@@ -168,7 +168,7 @@ def constrgen(rundir, args, globs):
             emsg = rungen(rundir, args, False, globs)
         else:
             if args.gui:
-                from Classes.mWidgets import mQDialogErr
+                from molSimplify.Classes.mWidgets import mQDialogErr
                 qqb = mQDialogErr(
                     'Error', 'No suitable ligand sets were found for random generation. Exiting...')
                 qqb.setParent(args.gui.wmain)

--- a/molSimplify/Scripts/structgen.py
+++ b/molSimplify/Scripts/structgen.py
@@ -9,23 +9,58 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from molSimplify.Scripts.geometry import *
-from molSimplify.Scripts.distgeom import *
-from molSimplify.Scripts.molSimplify_io import *
-if not sys.version_info >= (3,0):
-    from molSimplify.Scripts.nn_prep import *
-from molSimplify.Classes.globalvars import *
-from molSimplify.Classes.rundiag import *
-from molSimplify.Classes import globalvars
-from molSimplify.Classes import mol3D
-from molSimplify.Informatics.decoration_manager import*
-from molSimplify.Informatics.RACassemble import *
-from molSimplify.Scripts.krr_prep import *
-from molSimplify.Classes.ligand import ligand_breakdown, ligand_assign
-import os
+from math import pi
 import sys
-import time
-from pkg_resources import resource_filename, Requirement
+from molSimplify.Scripts.distgeom import (GetConf)
+from molSimplify.Classes.atom3D import atom3D
+from molSimplify.Classes.mol3D import (distance,
+                                       mol3D)
+from molSimplify.Scripts.geometry import (PointTranslateSph,
+                                          PointTranslateSphgivenr,
+                                          PointTranslatetoPSph,
+                                          aligntoaxis,
+                                          aligntoaxis2,
+                                          checkcolinear,
+                                          checkplanar,
+                                          getPointu,
+                                          kabsch,
+                                          midpt,
+                                          protate,
+                                          norm,
+                                          protateref,
+                                          reflect_through_plane,
+                                          rotateRef,
+                                          rotate_around_axis,
+                                          rotate_mat,
+                                          rotation_params,
+                                          setPdistance,
+                                          setPdistanceu,
+                                          vecangle,
+                                          vecdiff)
+from molSimplify.Scripts.molSimplify_io import (bind_load,
+                                                core_load,
+                                                getgeoms,
+                                                getinputargs,
+                                                getlicores,
+                                                getsubcores,
+                                                lig_load,
+                                                loadcoord,
+                                                loaddata,
+                                                loaddata_ts,
+                                                name_complex,
+                                                name_ts_complex,
+                                                substr_load)
+
+if not sys.version_info >= (3,0):
+    from molSimplify.Scripts.nn_prep import (ANN_preproc)
+from molSimplify.Classes.globalvars import (amassdict,
+                                            elementsbynum,
+                                            romans)
+from molSimplify.Classes.rundiag import ( run_diag )
+from molSimplify.Informatics.decoration_manager import (decorate_ligand)
+from molSimplify.Informatics.RACassemble import (assemble_connectivity_from_parts)
+from molSimplify.Classes.ligand import ligand_breakdown, ligand_assign, ligand
+from molSimplify.Classes.globalvars import globalvars
 import openbabel
 import random
 import itertools

--- a/molSimplify/Scripts/tf_nn_prep.py
+++ b/molSimplify/Scripts/tf_nn_prep.py
@@ -16,6 +16,7 @@ from molSimplify.python_nn.tf_ANN import *
 from molSimplify.__main__ import tensorflow_silence
 from molSimplify.python_nn.clf_analysis_tool import lse_trust
 import time
+from molSimplify.Classes.ligand import ligand
 from collections import OrderedDict
 
 

--- a/molSimplify/Scripts/tf_nn_prep.py
+++ b/molSimplify/Scripts/tf_nn_prep.py
@@ -5,19 +5,23 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from molSimplify.Scripts.geometry import *
-from molSimplify.Scripts.molSimplify_io import *
-from molSimplify.Informatics.decoration_manager import *
-from molSimplify.Classes.globalvars import *
-from molSimplify.Informatics.graph_analyze import *
-from molSimplify.Informatics.RACassemble import *
-from molSimplify.python_krr.sklearn_models import sklearn_supervisor
-from molSimplify.python_nn.tf_ANN import *
+import time
+import os
+
+from molSimplify.Classes.ligand import ligand
+from molSimplify.Classes.mol3D import mol3D
+from molSimplify.Classes.atom3D import atom3D
+from molSimplify.Scripts.molSimplify_io import lig_load
+from molSimplify.Informatics.RACassemble import (assemble_connectivity_from_parts,
+                                                 create_OHE,
+                                                 get_descriptor_vector)
+from molSimplify.Informatics.decoration_manager import (decorate_ligand)
 from molSimplify.__main__ import tensorflow_silence
 from molSimplify.python_nn.clf_analysis_tool import lse_trust
-import time
-from molSimplify.Classes.ligand import ligand
-from collections import OrderedDict
+from molSimplify.python_nn.tf_ANN import (ANN_supervisor,
+                                          find_ANN_10_NN_normalized_latent_dist,
+                                          find_ANN_latent_dist,
+                                          find_true_min_eu_dist)
 
 
 # import numpy

--- a/molSimplify/Scripts/tsgen.py
+++ b/molSimplify/Scripts/tsgen.py
@@ -5,22 +5,25 @@
 #
 #  Dpt of Chemical Engineering, MIT
 
-from molSimplify.Scripts.geometry import *
-from molSimplify.Scripts.structgen import *
-from molSimplify.Scripts.molSimplify_io import *
-from molSimplify.Scripts.nn_prep import *
-from molSimplify.Classes.globalvars import *
-from molSimplify.Classes.rundiag import *
-from molSimplify.Classes import globalvars
-from molSimplify.Classes import mol3D
-from molSimplify.Informatics.decoration_manager import*
-import os
-import sys
-import openbabel
-from pkg_resources import resource_filename, Requirement
-import random
-import itertools
-from numpy import log, arccos, cross, dot, pi
+from numpy import log
+
+from molSimplify.Classes.mol3D import (mol3D,
+                                       distance)
+from molSimplify.Classes.atom3D import atom3D
+from molSimplify.Classes.rundiag import (run_diag)
+from molSimplify.Scripts.geometry import (alignPtoaxis,
+                                          rotate_around_axis,
+                                          rotation_params,
+                                          vecangle,
+                                          vecdiff)
+from molSimplify.Scripts.molSimplify_io import (getinputargs)
+from molSimplify.Scripts.structgen import (PointTranslateSph,
+                                           align_lig_centersym,
+                                           check_rotate_linear_lig,
+                                           check_rotate_symm_lig,
+                                           ffopt,
+                                           getconnection,
+                                           rotate_MLaxis_minimize_steric)
 
 # XY sum cov rad coefficient
 XYcoeff = 1.1

--- a/molSimplify/job_manager/populate_jobs.py
+++ b/molSimplify/job_manager/populate_jobs.py
@@ -1,13 +1,12 @@
-import subprocess
-import copy
-import os
 import glob
 import numpy as np
+import os
 import shutil
-from molSimplify.Classes.mol3D import *
-from .tools import *
-import molSimplify.job_manager.manager_io as manager_io
+import subprocess
+
 from molSimplifyAD.utils.pymongo_tools import connect2db, query_lowestE_converged
+
+from molSimplify.job_manager.tools import (manager_io)
 
 
 def isCSD(job):

--- a/molSimplify/python_nn/ANN.py
+++ b/molSimplify/python_nn/ANN.py
@@ -8,13 +8,15 @@
 ##########################################################
 
 
-## import 
-from pybrain.structure import FeedForwardNetwork,TanhLayer,LinearLayer,BiasUnit,SigmoidLayer, FullConnection
-import numpy as np
 import csv
+
+import numpy as np
 from pkg_resources import resource_filename, Requirement
-from molSimplify.Classes.globalvars import *
-import sys,os
+
+from molSimplify.Classes.globalvars import (globalvars)
+from pybrain.structure import FeedForwardNetwork, TanhLayer, LinearLayer, BiasUnit, FullConnection
+
+
 def simple_network_builder(layers,partial_path):
     n = FeedForwardNetwork()
     ## create the network

--- a/molSimplify/python_nn/ensemble_test.py
+++ b/molSimplify/python_nn/ensemble_test.py
@@ -1,13 +1,30 @@
-from keras import backend as K
-from keras.callbacks import EarlyStopping
-from keras.models import model_from_json
-from .tf_ANN import *
-from sklearn.utils import shuffle
-from pkg_resources import resource_filename, Requirement
 import glob
+import math
+
 import numpy as np
 import scipy as sp
-import math
+import os
+from keras.callbacks import EarlyStopping
+from keras.models import model_from_json
+from keras import backend as K
+
+from pkg_resources import resource_filename, Requirement
+from sklearn.utils import shuffle
+from molSimplify.python_nn.clf_analysis_tool import (array_stack,
+                                                     dist_neighbor,
+                                                     get_entropy)
+from molSimplify.python_nn.tf_ANN import (data_normalize,
+                                          data_rescale,
+                                          get_key,
+                                          load_keras_ann,
+                                          load_normalization_data,
+                                          load_test_data,
+                                          load_test_labels,
+                                          load_train_info,
+                                          load_training_data,
+                                          load_training_labels,
+                                          save_model,
+                                          tf_ANN_excitation_prepare)
 
 
 def reset_weights(model):

--- a/molSimplify/python_nn/tf_ANN.py
+++ b/molSimplify/python_nn/tf_ANN.py
@@ -8,22 +8,20 @@
 ##########################################################
 
 
-## import 
-import keras
+import csv
+import glob
+import json
+import os
+
+import numpy as np
+import pandas as pd
+import scipy
 from keras import backend as K
 from keras.models import model_from_json, load_model
 from keras.optimizers import Adam
-import numpy as np
-import csv
 from pkg_resources import resource_filename, Requirement
-from .clf_analysis_tool import array_stack, get_layer_outputs, dist_neighbor, get_entropy
-from molSimplify.Classes.globalvars import *
-import sys, os
-import json
-import pandas as pd
-import glob
-import time
-import scipy
+
+from molSimplify.python_nn.clf_analysis_tool import array_stack, get_layer_outputs, dist_neighbor, get_entropy
 
 
 ## Functions


### PR DESCRIPTION
Many `import *` statements in the codebase led to confusion over where different functions were coming from. This commit converts **almost all** such statements into explicit imports, except those related to GUI functions or molscontrol. Additionally, two circular dependencies involving structgen were resolved. All changes pass Python 2 and Python 3 Travis-CI tests as of 2020-07-16.

The process for cleaning up imports was as follows:

- Initiate new git branch (fix_imports)
- Download dewildcard: `pip install dewildcard`
- For each file `file.py` in molSimplify:
  - Comment out imports inside conditionals
  - Use dewildcard on a file: `dewildcard -w file.py`
  - Open file.py in PyCharm and optimize imports
  - Scan code for import issues and add necessary imports to header
  - Uncomment imports found inside conditionals
  - Correct for any obvious issues, e.g. importing a module secondhand from another molSimplify module (e.g. `from molSimplify.Classes.mol3D import numpy`)
  - If file is broken according to PyCharm, roll it back

Local testing was performed using `python setup.py test`.