### PR TITLE
Add Python-only structure generation with `molSimplify.Scripts.generator.startgen_pythonic`

### DIFF
--- a/molSimplify/Scripts/generator.py
+++ b/molSimplify/Scripts/generator.py
@@ -51,7 +51,7 @@ from molSimplify.Scripts.rungen import (constrgen,
 # @param argv Default argument list used to "fool" startgen into accepting input_dict
 # @param flag Flag for printing information
 # @param gui Flag for GUI
-# @return tuple of:
+# @return tuple containing three elements:
 #  (
 #  where the run folder would have been [str],
 #  Error message [bool or str],

--- a/molSimplify/Scripts/generator.py
+++ b/molSimplify/Scripts/generator.py
@@ -46,18 +46,26 @@ from molSimplify.Scripts.rungen import (constrgen,
                                         multigenruns)
 
 
-# Coordinates subroutines
-#  @param argv Argument list
-#  @param flag Flag for printing information
-#  @param gui Flag for GUI
-#  @return Error messages
+# This is the main way to generate structures completely within Python
+# @param input_dict Argument list in the form of a dictionary
+# @param argv Default argument list used to "fool" startgen into accepting input_dict
+# @param flag Flag for printing information
+# @param gui Flag for GUI
+# @return tuple of:
+#  (
+#  where the run folder would have been [str],
+#  Error message [bool or str],
+#  diagnostics class object, containing ANN results (this_diag.ANN_attributes) and
+#     mol3D object (this_diag.mol)
+#  )
 def startgen_pythonic(input_dict={'-core': 'fe', '-lig': 'cl,cl,cl,cl,cl,cl'},
                       argv=['main.py', '-i', 'asdfasdfasdfasdf'],
                       flag=True,
                       gui=False):
     # from molSimplify.Scripts.generator import startgen_pythonic
     inputfile_str = '\n'.join([k + ' ' + v for k, v in input_dict.items()])
-    return startgen(argv, flag, gui, inputfile_str, write_files=False)
+    strfiles, emsg, this_diag = startgen(argv, flag, gui, inputfile_str, write_files=False)
+    return (strfiles, emsg, this_diag)
 
 # Coordinates subroutines
 #  @param argv Argument list

--- a/molSimplify/Scripts/generator.py
+++ b/molSimplify/Scripts/generator.py
@@ -57,14 +57,14 @@ def startgen_pythonic(input_dict={'-core': 'fe', '-lig': 'cl,cl,cl,cl,cl,cl'},
                       gui=False):
     # from molSimplify.Scripts.generator import startgen_pythonic
     inputfile_str = '\n'.join([k + ' ' + v for k, v in input_dict.items()])
-    startgen(argv, flag, gui, inputfile_str)
+    return startgen(argv, flag, gui, inputfile_str, write_files=False)
 
 # Coordinates subroutines
 #  @param argv Argument list
 #  @param flag Flag for printing information
 #  @param gui Flag for GUI
 #  @return Error messages
-def startgen(argv, flag, gui, inputfile_str=None):
+def startgen(argv, flag, gui, inputfile_str=None, write_files=True):
     emsg = False
     # check for configuration file
     homedir = os.path.expanduser("~")
@@ -143,7 +143,8 @@ def startgen(argv, flag, gui, inputfile_str=None):
     # check for jobs directory
     rundir = args.rundir+'/' if (args.rundir) else rundir
     if not os.path.isdir(rundir):
-        os.mkdir(rundir)
+        if write_files:
+            os.mkdir(rundir)
     ################### START MAIN ####################
     args0 = copy.deepcopy(args)  # save initial arguments
     # add gui flag
@@ -217,7 +218,7 @@ def startgen(argv, flag, gui, inputfile_str=None):
             print('building an equilibrium complex')
         for cc in corests:
             args.core = cc
-            emsg = multigenruns(rundir, args, globs)
+            emsg = multigenruns(rundir, args, globs, write_files=write_files)
             if emsg:
                 print(emsg)
                 del args

--- a/molSimplify/Scripts/generator.py
+++ b/molSimplify/Scripts/generator.py
@@ -51,7 +51,20 @@ from molSimplify.Scripts.rungen import (constrgen,
 #  @param flag Flag for printing information
 #  @param gui Flag for GUI
 #  @return Error messages
-def startgen(argv, flag, gui):
+def startgen_pythonic(input_dict={'-core': 'fe', '-lig': 'cl,cl,cl,cl,cl,cl'},
+                      argv=['main.py', '-i', 'asdfasdfasdfasdf'],
+                      flag=True,
+                      gui=False):
+    # from molSimplify.Scripts.generator import startgen_pythonic
+    inputfile_str = '\n'.join([k + ' ' + v for k, v in input_dict.items()])
+    startgen(argv, flag, gui, inputfile_str)
+
+# Coordinates subroutines
+#  @param argv Argument list
+#  @param flag Flag for printing information
+#  @param gui Flag for GUI
+#  @return Error messages
+def startgen(argv, flag, gui, inputfile_str=None):
     emsg = False
     # check for configuration file
     homedir = os.path.expanduser("~")
@@ -89,14 +102,14 @@ def startgen(argv, flag, gui):
     parser = argparse.ArgumentParser()
     args = parseall(parser)
     # check if input file exists
-    if not glob.glob(args.i):
+    if not glob.glob(args.i) and not inputfile_str:
         emsg = 'Input file '+args.i+' does not exist. Please specify a valid input file.\n'
         print(emsg)
         return emsg
     args.gui = gui  # add gui flag
     # parse input file
-    if args.i:
-        parseinputfile(args)
+    if args.i or inputfile_str:
+        parseinputfile(args, inputfile_str=inputfile_str)
     if args.cdxml:
         print('converting cdxml file into xyz')
         cdxml = args.cdxml[0]

--- a/molSimplify/Scripts/inparse.py
+++ b/molSimplify/Scripts/inparse.py
@@ -527,7 +527,7 @@ def parseCLI(args):
 #  @param args Namespace of arguments
 
 
-def parseinputfile(args):
+def parseinputfile(args, inputfile_str=None):
     # arguments that don't match with  inparse name and
     # are not automatically initialized go here:
     args.skipANN = False
@@ -541,8 +541,12 @@ def parseinputfile(args):
 
     # (we should remove these where posible)
     # THIS NEEDS CLEANING UP TO MINIMIZE DUPLICATION WITH parsecommandline
+    if inputfile_str:
+        inputfile_lines = inputfile_str.split('\n')
+    else:
+        inputfile_lines = open(args.i)
 
-    for line in open(args.i):
+    for line in inputfile_lines:
         # For arguments that cannot accept smiles as args, split possible comments
         if '-lig' not in line and '-core' not in line and '-bind' not in line and '-dbsmarts' not in line:
             line = line.split('#')[0]  # remove comments

--- a/molSimplify/Scripts/structgen.py
+++ b/molSimplify/Scripts/structgen.py
@@ -3882,7 +3882,12 @@ def structgen_one(strfiles, args, rootdir, ligands, ligoc, globs, sernum, nconf=
         this_diag.write_report(fname+'.report')
         # write input file from command line arguments
         getinputargs(args, fname)
-    del core3D
+    # (Possibly breaking change) Copy core3D into this_diag
+    core3D_copy = mol3D()
+    core3D_copy.copymol3D(core3D)
+    this_diag.set_mol(core3D_copy)
+
+    del core3D # Legacy code, unsure if needed
     return strfiles, emsg, this_diag
 
 # Main structure generation routine - multiple structures

--- a/molSimplify/Scripts/structgen.py
+++ b/molSimplify/Scripts/structgen.py
@@ -3584,7 +3584,7 @@ def msubcomplex(args, core3D, substrate, sub_i, subcatoms, mlig, subcatoms_ext, 
 #  @return List of xyz files generated, error messages
 
 
-def structgen_one(strfiles, args, rootdir, ligands, ligoc, globs, sernum, nconf=False):
+def structgen_one(strfiles, args, rootdir, ligands, ligoc, globs, sernum, nconf=False, write_files=True):
     # load ligand dictionary
     licores = getlicores()
     subcores = getsubcores()
@@ -3807,6 +3807,7 @@ def structgen_one(strfiles, args, rootdir, ligands, ligoc, globs, sernum, nconf=
     if args.debug:
         print(('fname is ' + fname))
     # generate ts
+    # The write_files flag is ineffective for this portion of code
     if (args.tsgen):
         substrate = []
         for i in args.substrate:
@@ -3872,14 +3873,15 @@ def structgen_one(strfiles, args, rootdir, ligands, ligoc, globs, sernum, nconf=
             getinputargs(args, fname)
         return strfiles, emsg, this_diag
     # write xyz file
-    if not args.reportonly:
+    if (not args.reportonly) and (write_files):
         core3D.writexyz(fname)
     strfiles.append(fname)
-    # write report file
-    this_diag.set_mol(core3D)
-    this_diag.write_report(fname+'.report')
-    # write input file from command line arguments
-    getinputargs(args, fname)
+    if write_files:
+        # write report file
+        this_diag.set_mol(core3D)
+        this_diag.write_report(fname+'.report')
+        # write input file from command line arguments
+        getinputargs(args, fname)
     del core3D
     return strfiles, emsg, this_diag
 
@@ -3893,7 +3895,7 @@ def structgen_one(strfiles, args, rootdir, ligands, ligoc, globs, sernum, nconf=
 #  @return List of xyz files generated, error messages
 
 
-def structgen(args, rootdir, ligands, ligoc, globs, sernum):
+def structgen(args, rootdir, ligands, ligoc, globs, sernum, write_files=True):
     emsg = False
     # import gui options
     if args.gui:
@@ -3913,14 +3915,14 @@ def structgen(args, rootdir, ligands, ligoc, globs, sernum):
             for n in range(1, int(args.nconfs)+1):
                 print(('Generating conformer '+str(n)+' of '+args.nconfs+':'))
                 strfiles, emsg, this_diag = structgen_one(
-                    strfiles, args, rootdir, ligands, ligoc, globs, sernum, n)
+                    strfiles, args, rootdir, ligands, ligoc, globs, sernum, n, write_files=write_files)
                 print(strfiles)
         else:
             strfiles, emsg, this_diag = structgen_one(
-                strfiles, args, rootdir, ligands, ligoc, globs, sernum)
+                strfiles, args, rootdir, ligands, ligoc, globs, sernum, write_files=write_files)
     else:
         strfiles, emsg, this_diag = structgen_one(
-            strfiles, args, rootdir, ligands, ligoc, globs, sernum)
+            strfiles, args, rootdir, ligands, ligoc, globs, sernum, write_files=write_files)
 
     # score conformers
     conf3Ds = dict()
@@ -3944,6 +3946,7 @@ def structgen(args, rootdir, ligands, ligoc, globs, sernum):
     else:
         Nogeom = 1
     # generate multiple geometric arrangements
+    # Code below may be invalid because core3D is not defined
     if args.bind:
         # load bind, add hydrogens and convert to mol3D
         bind, bsmi, emsg = bind_load(args.bind)

--- a/molSimplify/__main__.py
+++ b/molSimplify/__main__.py
@@ -188,7 +188,6 @@ def main(args=None):
         print('molSimplify is starting!')
         gui = False
         # run from commandline
-        print sys.argv
         emsg = startgen(sys.argv, False, gui)
     ### grab from commandline arguments ###
     else:

--- a/molSimplify/__main__.py
+++ b/molSimplify/__main__.py
@@ -188,6 +188,7 @@ def main(args=None):
         print('molSimplify is starting!')
         gui = False
         # run from commandline
+        print sys.argv
         emsg = startgen(sys.argv, False, gui)
     ### grab from commandline arguments ###
     else:


### PR DESCRIPTION
We created a new function to generate mol3Ds using Python only, i.e. without using input files or writing output files. It is startgen_pythonic under molSimplify.Scripts.generator. It passes the following Travis build: https://travis-ci.org/github/hjkgrp/molSimplify/builds/710162994

Here are some example usages of the function:

```python
from molSimplify.Scripts.generator import startgen_pythonic

# Input file parameters to generate a mol3D from

# Example 1: Generate a fe(cl)6 complex
input_dict = {'-core': 'fe', '-lig': 'cl,cl,cl,cl,cl,cl'}

# Example 2: Generate a fe(cl)6 complex very fast (skip ANN)
#input_dict = {'-core': 'fe', '-lig': 'cl,cl,cl,cl,cl,cl', '-skipANN', 'True'}

# Example 3: Generate a co(cl)4 tetrahedral complex
#input_dict = {'-core': 'cobalt', '-geometry': 'thd', '-lig': 'cl'})

# Generate a structure and run neural networks
run_path, emsg, results = startgen_pythonic(input_dict=input_dict)

# Extract the mol3D
mymol = results.mol

# Extract the ANN results
my_ANN_results = results.ANN_attributes
```

With this, you can generate new mol3D’s directly within Python without having to read/write files.