### PR TITLE
faster distance function for MOF features

### DIFF
--- a/molSimplify/Informatics/MOF/MOF_descriptors.py
+++ b/molSimplify/Informatics/MOF/MOF_descriptors.py
@@ -268,7 +268,7 @@ def get_MOF_descriptors(data, depth, path=False, xyzpath = False):
         tmpstr = "Failed to featurize %s: large primitive cell\n"%(name)
         write2file(path,"/FailedStructures.log",tmpstr)
         return full_names, full_descriptors
-    distance_mat = compute_distance_matrix2(cell_v,cart_coords)
+    distance_mat = compute_distance_matrix3(cell_v,cart_coords)
     try:
         adj_matrix=compute_adj_matrix(distance_mat,allatomtypes)
     except NotImplementedError:

--- a/molSimplify/Informatics/MOF/PBC_functions.py
+++ b/molSimplify/Informatics/MOF/PBC_functions.py
@@ -295,6 +295,18 @@ def compute_distance_matrix2(cell,cart_coords):
 
     return distance_matrix
 
+def compute_distance_matrix3(cell, cart_coords, num_cells = 1):
+    pos = np.arange(-num_cells, num_cells+1, 1)
+    combos = np.array(np.meshgrid(pos, pos, pos)).T.reshape(-1,3)
+    shifts = np.sum(np.expand_dims(cell, axis=0)*np.expand_dims(combos, axis=-1), axis=1)
+    # NxNxCells distance array
+    shifted = np.expand_dims(cart_coords, axis=1) + np.expand_dims(shifts, axis=0)
+    dist = np.expand_dims(np.expand_dims(cart_coords, axis=1), axis=1) - np.expand_dims(shifted,axis=0)
+    dist = np.sqrt(np.sum(np.square(dist), axis=-1))
+    # But we want only min
+    distance_matrix = np.min(dist, axis=-1)
+    return distance_matrix
+
 
 def make_graph_from_nodes_edges(nodes,edges,attribs):
     gr = nx.Graph()


### PR DESCRIPTION
Dear molSimplify developers,

Thanks for your great work!

We ran into a bottleneck for large MOF unit cells in the compute_distance_matrix2 function in MOF_descriptors.py. We added a new function which is significantly faster (~5 seconds compared to ~100 seconds for a MOF with 700 atoms in the unit cell).

It would be great to integrate this into molSimplify!

Best regards and thanks
Pascal Friederich

T.T.-Prof. Dr. Pascal Friederich
Artificial Intelligence for Materials Science
Department of Computer Science & Institute of Nanotechnology
Karlsruhe Institute of Technology
https://aimat.science
pascal.friederich@kit.edu

