### PR TITLE
Minor bugfixes

### DIFF
--- a/molSimplify/Scripts/distgeom.py
+++ b/molSimplify/Scripts/distgeom.py
@@ -228,7 +228,9 @@ def Metrize(LB, UB, natoms, Full=False, seed=False):
         numpy.random.seed(seed)
     D = np.zeros((natoms, natoms))
     LB, UB = Triangle(LB, UB, natoms)
-    #First generate a random distance for all atom pairings not involving the metal
+    # First generate a random distance for all atom pairings not involving
+    # the metal. TODO: j should start from i+1 to ensure the diagonal is
+    # zero.
     for i in range(natoms-1):
         for j in range(i, natoms-1):
             # ~ if Full:
@@ -237,9 +239,12 @@ def Metrize(LB, UB, natoms, Full=False, seed=False):
                 UB[i][j] = LB[i][j]
             D[i][j] = np.random.uniform(LB[i][j], UB[i][j])
             D[j][i] = D[i][j]
-    
-    #For pairs involving the metal, set the distance to 100 Angstroms regardless of the triangle rule
-    #This encourages the algorithm to select conformations which don't crowd the metal, as these often lead to failure
+
+    # For pairs involving the metal, set the distance to 100 Angstroms
+    # regardless of the triangle rule. This encourages the algorithm to
+    # select conformations which don't crowd the metal, as these often lead
+    # to failure. TODO: loop over j should only run to natoms - 1 to avoid
+    # writing to the diagonal.
     for j in range(natoms):
         if UB[natoms-1][j] < LB[natoms-1][j]:  # ensure that the upper bound is larger than the lower bound
             UB[natoms-1][j] = LB[natoms-1][j]
@@ -267,15 +272,19 @@ def GetCMDists(D, natoms):
 
     """
     D0 = np.zeros(natoms)
-    status = True
     for i in range(natoms):
         for j in range(natoms):
             D0[i] += D[i][j]**2/natoms
         for j in range(natoms):
             for k in range(j, natoms):
                 D0[i] -= (D[j][k])**2/natoms**2
-        D0[i] = sqrt(D0[i])
-    return D0, status
+        try:
+            D0[i] = sqrt(D0[i])
+        except ValueError:
+            # If the triangle inequality is not sastisfied D0[i]
+            # is negative and sqrt raises a value error.
+            return D0, False
+    return D0, True
 
 def GetMetricMatrix(D, D0, natoms):
     """Get metric matrix from distance matrix and CM distances 

--- a/molSimplify/Scripts/inparse.py
+++ b/molSimplify/Scripts/inparse.py
@@ -328,7 +328,7 @@ def checkinput(args, calctype="base"):
             # check mlig connecting point if the ligand has more than one atom
             if args.mlig and not args.mligcatoms:
                 sub, subcatoms, emsg = substr_load(args.mlig[0], 0, subcatoms)
-                if sub.natoms is 1:
+                if sub.natoms == 1:
                     args.mligcatoms = [0]
                 else:
                     print('WARNING: A ligand in the metal complex is specified to connect with the substrate for TS generation without the specification of a connection point in the ligand. Defaulting to atom index 0.')

--- a/molSimplify/Scripts/inparse.py
+++ b/molSimplify/Scripts/inparse.py
@@ -483,7 +483,7 @@ def cleaninput(args):
                 args.keepHs[i] = checkTrue(s)
     # parse FF settings:
     # if no FF opt is requested, turn off
-    if args.ffoption[0].lower() == ('n' or 'no'):
+    if args.ffoption[0].lower() in ['n', 'no']:
         args.ff = False
     # if FF opt is desired, parse FF choice
     else:

--- a/molSimplify/job_manager/manager_io.py
+++ b/molSimplify/job_manager/manager_io.py
@@ -694,7 +694,7 @@ def write_jobscript(name, custom_line=None, time_limit='96:00:00', qm_code='tera
 
 def write_terachem_jobscript(name, custom_line=None, time_limit='96:00:00', terachem_line=True, 
                              machine='gibraltar', cwd=False, use_molscontrol=False, queues = ['gpus','gpusnew']):
-    if use_molscontrol and machine is not 'gibraltar':
+    if use_molscontrol and machine != 'gibraltar':
         raise ValueError("molscontrol is only implemented on gibraltar for now.")
     jobscript = open(name + '_jobscript', 'w')
     if machine == 'gibraltar':

--- a/tests/test_distgeom.py
+++ b/tests/test_distgeom.py
@@ -1,5 +1,26 @@
 import numpy as np
-from molSimplify.Scripts.distgeom import GetCMDists, CosRule
+from molSimplify.Scripts.distgeom import GetCMDists, CosRule, Metrize
+
+
+def test_CosRule(atol=1e-6):
+    # Test simple "unit" triangle
+    assert abs(CosRule(1., 1., 90) - np.sqrt(2)) < atol
+    assert abs(CosRule(1, np.sqrt(2), 45) - 1.) < atol
+    assert abs(CosRule(np.sqrt(2), 1., 45) - 1.) < atol
+    # Test equilateral triangle
+    a = 3.456
+    assert abs(CosRule(a, a, 60) - a) < atol
+    # Test Pythagoras
+    assert abs(CosRule(3., 4., 90) - 5.) < atol
+    # Test 30-60-90 triangle
+    a = 2.345
+    assert abs(CosRule(a, 0.5*a*np.sqrt(3), 30) - 0.5*a) < atol
+    assert abs(CosRule(a, 0.5*a, 60) - 0.5*a*np.sqrt(3)) < atol
+    assert abs(CosRule(0.5*a, 0.5*a*np.sqrt(3), 90) - a) < atol
+    # Test symmetry on 30-60-90
+    assert abs(CosRule(0.5*a*np.sqrt(3), a, 30) - 0.5*a) < atol
+    assert abs(CosRule(0.5*a, a, 60) - 0.5*a*np.sqrt(3)) < atol
+    assert abs(CosRule(0.5*a*np.sqrt(3), 0.5*a, 90) - a) < atol
 
 
 def test_GetCMDists():
@@ -18,24 +39,39 @@ def test_GetCMDists():
     dists_ref = np.sqrt(np.sum((xyzs - center)**2, axis=-1))
 
     dists, status = GetCMDists(dist_mat, len(xyzs))
-    np.testing.assert_allclose(dists, dists_ref)
-    # What is status even used for? Always returns True!
     assert status
+    np.testing.assert_allclose(dists, dists_ref)
 
 
-def test_CosRule(atol=1e-6):
-    # Test simple "unit" triangle
-    assert abs(CosRule(1., 1., 90) - np.sqrt(2)) < atol
-    assert abs(CosRule(1, np.sqrt(2), 45) - 1.) < atol
-    assert abs(CosRule(np.sqrt(2), 1., 45) - 1.) < atol
-    # Test Pythagoras
-    assert abs(CosRule(3., 4., 90) - 5.) < atol
-    # Test 30-60-90 triangle
-    a = 2.345
-    assert abs(CosRule(a, 0.5*a*np.sqrt(3), 30) - 0.5*a) < atol
-    assert abs(CosRule(a, 0.5*a, 60) - 0.5*a*np.sqrt(3)) < atol
-    assert abs(CosRule(0.5*a, 0.5*a*np.sqrt(3), 90) - a) < atol
-    # Test symmetry on 30-60-90
-    assert abs(CosRule(0.5*a*np.sqrt(3), a, 30) - 0.5*a) < atol
-    assert abs(CosRule(0.5*a, a, 60) - 0.5*a*np.sqrt(3)) < atol
-    assert abs(CosRule(0.5*a*np.sqrt(3), 0.5*a, 90) - a) < atol
+def test_Metrize():
+    """"A few tests are commented out because they would only be
+    satisfied after introducing breaking changes to Metrize()
+    (see TODO tags)"""
+    # Setup
+    natoms = 9
+    LB = np.zeros((natoms, natoms))
+    UB = 100*np.ones((natoms, natoms))
+    # Build distance matrix
+    D = Metrize(LB, UB, natoms)
+    # Test bounds
+    np.testing.assert_array_compare(np.greater_equal, D, LB)
+    np.testing.assert_array_compare(np.less_equal, D, UB)
+    # Test symmetry
+    np.testing.assert_equal(D, D.T)
+    # Diagonal should be zero
+    # np.testing.assert_equal(np.diag(D), np.zeros(natoms))
+    # Test triangle inequality. For each triangle of atoms i, j, and k:
+    # r_ij <= r_ik + r_kj. TODO the current implementation occasionally
+    # breaks the constraint on purpose for a potential speed up.
+    # for i in range(natoms):
+    #     for j in range(i, natoms):  # Test only lower triangular matrix
+    #         for k in range(natoms):
+    #             assert D[i, j] <= D[i, k] + D[k, j]
+    # Test elements for specific seed
+    # D = Metrize(LB, UB, natoms, seed=1234)
+    # Reference for the seed
+    # ref = np.array([[0.,        19.151945, 62.210877, 100.],
+    #                 [19.151945, 0.,        43.772774, 100.],
+    #                 [62.210877, 43.772774, 0.,        100.],
+    #                 [100.,      100.,      100.,      0.]])
+    # np.testing.assert_allclose(D, ref)

--- a/tests/test_distgeom.py
+++ b/tests/test_distgeom.py
@@ -1,0 +1,41 @@
+import numpy as np
+from molSimplify.Scripts.distgeom import GetCMDists, CosRule
+
+
+def test_GetCMDists():
+    # Dummy points in 3d
+    xyzs = np.array([[0., 0., 0.],
+                     [1., 0., 0.],
+                     [0., 1., 0.],
+                     [0., 1., 1.],
+                     [0., 0., 0.]])
+
+    dist_mat = np.sqrt(np.sum(
+        (xyzs[np.newaxis, :, :] - xyzs[:, np.newaxis, :])**2, axis=-1))
+    # Calculate geometric center
+    center = np.mean(xyzs, axis=0)
+    # Distances to the center:
+    dists_ref = np.sqrt(np.sum((xyzs - center)**2, axis=-1))
+
+    dists, status = GetCMDists(dist_mat, len(xyzs))
+    np.testing.assert_allclose(dists, dists_ref)
+    # What is status even used for? Always returns True!
+    assert status
+
+
+def test_CosRule(atol=1e-6):
+    # Test simple "unit" triangle
+    assert abs(CosRule(1., 1., 90) - np.sqrt(2)) < atol
+    assert abs(CosRule(1, np.sqrt(2), 45) - 1.) < atol
+    assert abs(CosRule(np.sqrt(2), 1., 45) - 1.) < atol
+    # Test Pythagoras
+    assert abs(CosRule(3., 4., 90) - 5.) < atol
+    # Test 30-60-90 triangle
+    a = 2.345
+    assert abs(CosRule(a, 0.5*a*np.sqrt(3), 30) - 0.5*a) < atol
+    assert abs(CosRule(a, 0.5*a, 60) - 0.5*a*np.sqrt(3)) < atol
+    assert abs(CosRule(0.5*a, 0.5*a*np.sqrt(3), 90) - a) < atol
+    # Test symmetry on 30-60-90
+    assert abs(CosRule(0.5*a*np.sqrt(3), a, 30) - 0.5*a) < atol
+    assert abs(CosRule(0.5*a, a, 60) - 0.5*a*np.sqrt(3)) < atol
+    assert abs(CosRule(0.5*a*np.sqrt(3), 0.5*a, 90) - a) < atol


### PR DESCRIPTION
A few bugs that I encountered during my geometry optimization investigations. The only important change is in `GetCMDists()` which now includes a `try except` block to cover the case of distance matrices that do not satisfy the triangle inequality. This workaround would not be needed if we fixed the `Metrize()` function, which I am not comfortable doing alone since it impacts core functionality for conformer construction.