### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,8 @@ setup(name='molSimplify',
           'molSimplify': ["Data/*.dat", "Bind/*.dat", "Ligands/*.dict", "icons/*.png",
                           "python_nn/*.csv", "python_krr/*.csv", "tf_nn/*/*", "molscontrol/*/*"]
       },
-      data_files=[("molSimplify", ["molSimplify/Data/ML.dat"])],
-      install_requirements=['numpy', 'scipy', 'scikit-learn',
-                            'pandas', 'keras', 'tensorflow', 'pyyaml'],
+      install_requires=['numpy', 'scipy', 'scikit-learn',
+                        'pandas', 'keras', 'tensorflow', 'pyyaml'],
       setup_requires=['pytest-runner'], # this may result some package conflict in local conda build. comment it out if needed.
       tests_require=['pytest'],
       include_package_data=True

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,24 @@
 from setuptools import setup, find_packages
 
 setup(name='molSimplify',
-      version="v1.6.0",
+      version='v1.6.0',
       packages=find_packages(),
       entry_points={
-          'console_scripts': ['molsimplify = molSimplify.__main__:main',
-                              'molscontrol = molSimplify.molscontrol.molscontrol:main',
-                              'jobmanager = molSimplify.job_manager.resub:main']
+          'console_scripts': [
+              'molsimplify = molSimplify.__main__:main',
+              'molscontrol = molSimplify.molscontrol.molscontrol:main',
+              'jobmanager = molSimplify.job_manager.resub:main']
       },
       package_dir={'molSimplify': 'molSimplify'},
       package_data={
-          'molSimplify': ["Data/*.dat", "Bind/*.dat", "Ligands/*.dict", "icons/*.png",
-                          "python_nn/*.csv", "python_krr/*.csv", "tf_nn/*/*", "molscontrol/*/*"]
+          'molSimplify': ['Data/*.dat', 'Bind/*.dat', 'Ligands/*.dict',
+                          'icons/*.png', 'python_nn/*.csv', 'python_krr/*.csv',
+                          'tf_nn/*/*', 'molscontrol/*/*']
       },
+      data_files=[('molSimplify', ['molSimplify/Data/ML.dat'])],
       install_requires=['numpy', 'scipy', 'scikit-learn',
                         'pandas', 'keras', 'tensorflow', 'pyyaml'],
-      setup_requires=['pytest-runner'], # this may result some package conflict in local conda build. comment it out if needed.
+      setup_requires=['pytest-runner'],  # this may result some package conflict in local conda build. comment it out if needed.
       tests_require=['pytest'],
       include_package_data=True
       )


### PR DESCRIPTION
Not sure if this PR actually fixes anything (might be that I just do not know enough about setuptools):

Main contribution is the change of `install_requirements` to `install_requires`. AFAIK the former is not an actual keyword argument of setup (see https://setuptools.pypa.io/en/latest/userguide/dependency_management.html).

For consistency (at least within one file) double quotes are replaced by single quotes.