### PR TITLE
Reduce slack notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,5 +46,7 @@ script:
   # - molsimplify -h
 
 notifications:
-  slack: hjklol:tIyrsTGNRmimRH5PcbzOVpvO
+  slack:
     if: branch = master
+    rooms:
+      - hjklol:tIyrsTGNRmimRH5PcbzOVpvO

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,4 +46,5 @@ script:
   # - molsimplify -h
 
 notifications:
-          slack: hjklol:tIyrsTGNRmimRH5PcbzOVpvO  
+  slack: hjklol:tIyrsTGNRmimRH5PcbzOVpvO
+    if: branch = master


### PR DESCRIPTION
Implements @chenruduan's suggestions of restricting slack build notifications for Travis-CI builds to the master branch.