### PR TITLE
Enable caching of the conda env for CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -43,12 +43,12 @@ jobs:
 
     # More info on the whole conda setup: https://github.com/conda-incubator/setup-miniconda
     - name: Setup Mambaforge
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-            miniforge-variant: Mambaforge
-            miniforge-version: latest
-            activate-environment: mols_test
-            use-mamba: true
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: mols_test
+          use-mamba: true
     # Get date for the cache key
     - name: Get current time
       uses: josStorer/get-current-time@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -57,7 +57,7 @@ jobs:
       id: cache
       env:
         # Increase this value to reset cache if mols.yml has not changed
-        CACHE_NUMBER: 1
+        CACHE_NUMBER: 0
       with:
         # TODO: Figure out how to avoid this hard coded path. For some reason $CONDA does not work.
         path: /usr/share/miniconda/envs/mols_test

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -44,6 +44,7 @@ jobs:
     # More info on the whole conda setup: https://github.com/conda-incubator/setup-miniconda
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2
+      id: conda-setup
       with:
         activate-environment: mols_test
     # Get date for the cache key
@@ -58,7 +59,7 @@ jobs:
         # Increase this value to reset cache if mols.yml has not changed
         CACHE_NUMBER: 0
       with:
-        path: ${{ env.CONDA }}/envs
+        path: ${{ steps.conda-setup.env.CONDA }}/envs
         key:
           # Key contains current year and month to ensure it is updated once a month
           ${{ runner.os }}-${{ runner.arch }}-conda-${{ steps.current-time.outputs.year }}-${{

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -64,7 +64,8 @@ jobs:
         key:
           # Key contains current year and month to ensure it is updated once a month
           ${{ runner.os }}-${{ runner.arch }}-conda-${{ steps.current-time.outputs.year }}-${{
-          steps.current-time.outputs.month }}-${{ hashFiles('devtools/conda-envs/mols.yml') }}-${{ env.CACHE_NUMBER }}
+          steps.current-time.outputs.month }}-${{ hashFiles('devtools/conda-envs/mols.yml') }}-${{
+          env.CACHE_NUMBER }}
     # Install environment from yaml file if cache-hit == false
     - name: Update conda env
       run: conda env update -n mols_test -f devtools/conda-envs/mols.yml

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -29,42 +29,46 @@ jobs:
         include:
           - os: ubuntu-latest
             python-version: 3.7
-
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
 
     - name: Additional info about the build
-      shell: bash
       run: |
         uname -a
         df -h
         ulimit -a
+
     # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - uses: conda-incubator/setup-miniconda@v2
+    - name: Cache conda
+        uses: actions/cache@v2
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-${{ runner.arch }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('devtools/conda-envs/mols.yml') }}
+
+    - name: Setup conda
+      uses: conda-incubator/setup-miniconda@v2
       with:
         python-version: ${{ matrix.python-version }}
         environment-file: devtools/conda-envs/mols.yml
-
-        channels: conda-forge,defaults
-
+        use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
         activate-environment: mols_test
         auto-update-conda: false
         auto-activate-base: false
         show-channel-urls: true
 
     - name: Install package
-
-      # conda setup requires this special shell
-      shell: bash -l {0}
       run: |
         pip install -e .
         conda list
     
     - name: Run tests
-
-      # conda setup requires this special shell
-      shell: bash -l {0}
-
       run: |
         pytest -v tests/
         
@@ -75,7 +79,7 @@ jobs:
       uses: 8398a7/action-slack@v3
       with:
         job_name: Test on ${{ matrix.os }}, Python ${{ matrix.python-version }}
-        fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+        fields: message,commit,author,workflow,job,took
         status: ${{ job.status }}
       env:
         SLACK_WEBHOOK_URL: ${{secrets.SLACK_WEBHOOK}}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -41,27 +41,35 @@ jobs:
         df -h
         ulimit -a
 
-    # More info on options: https://github.com/conda-incubator/setup-miniconda
-    - name: Cache conda
+    # More info on the whole conda setup: https://github.com/conda-incubator/setup-miniconda
+    - name: Setup Mambaforge
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+            miniforge-variant: Mambaforge
+            miniforge-version: latest
+            activate-environment: mols_test
+            use-mamba: true
+    # Get date for the cache key
+    - name: Get current time
+      uses: josStorer/get-current-time@v2
+      id: current-time
+    # Actual caching
+    - name: Cache conda env
       uses: actions/cache@v2
+      id: cache
       env:
-        # Increase this value to reset cache if etc/example-environment.yml has not changed
+        # Increase this value to reset cache if mols.yml has not changed
         CACHE_NUMBER: 0
       with:
-        path: ~/conda_pkgs_dir
+        path: ${{ env.CONDA }}/envs
         key:
-          ${{ runner.os }}-${{ runner.arch }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('devtools/conda-envs/mols.yml') }}
-
-    - name: Setup conda
-      uses: conda-incubator/setup-miniconda@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-        environment-file: devtools/conda-envs/mols.yml
-        use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-        activate-environment: mols_test
-        auto-update-conda: false
-        auto-activate-base: false
-        show-channel-urls: true
+          # Key contains current year and month to ensure it is updated once a month
+          ${{ runner.os }}-${{ runner.arch }}-conda-${{ steps.current-time.outputs.year }}-${{
+          steps.current-time.outputs.month }}-${{ hashFiles('devtools/conda-envs/mols.yml') }}-${{ env.CACHE_NUMBER }}
+    # Install environment from yaml file if cache-hit == false
+    - name: Update conda env
+      run: mamba env update -n mols_test -f devtools/conda-envs/mols.yml
+      if: steps.cache.outputs.cache-hit != 'true'
 
     - name: Install package
       run: |

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -44,6 +44,7 @@ jobs:
     # More info on the whole conda setup: https://github.com/conda-incubator/setup-miniconda
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2
+      id: conda-setup
       with:
         activate-environment: mols_test
     # Get date for the cache key
@@ -56,9 +57,10 @@ jobs:
       id: cache
       env:
         # Increase this value to reset cache if mols.yml has not changed
-        CACHE_NUMBER: 0
+        CACHE_NUMBER: 1
       with:
-        path: ${{ env.CONDA_PREFIX }}/envs
+        # TODO: Figure out how to avoid this hard coded path. For some reason $CONDA does not work.
+        path: /usr/share/miniconda/envs/mols_test
         key:
           # Key contains current year and month to ensure it is updated once a month
           ${{ runner.os }}-${{ runner.arch }}-conda-${{ steps.current-time.outputs.year }}-${{

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -44,7 +44,6 @@ jobs:
     # More info on the whole conda setup: https://github.com/conda-incubator/setup-miniconda
     - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2
-      id: conda-setup
       with:
         activate-environment: mols_test
     # Get date for the cache key
@@ -59,7 +58,7 @@ jobs:
         # Increase this value to reset cache if mols.yml has not changed
         CACHE_NUMBER: 0
       with:
-        path: ${{ steps.conda-setup.env.CONDA }}/envs
+        path: ${{ env.CONDA_PREFIX }}/envs
         key:
           # Key contains current year and month to ensure it is updated once a month
           ${{ runner.os }}-${{ runner.arch }}-conda-${{ steps.current-time.outputs.year }}-${{

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -73,6 +73,7 @@ jobs:
     - name: Install package
       run: |
         pip install -e .
+        pip install pytest-cov
         conda list
     
     - name: Run tests

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -45,10 +45,10 @@ jobs:
     - name: Setup Mambaforge
       uses: conda-incubator/setup-miniconda@v2
       with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          activate-environment: mols_test
-          use-mamba: true
+        miniforge-variant: Mambaforge
+        miniforge-version: latest
+        activate-environment: mols_test
+        use-mamba: true
     # Get date for the cache key
     - name: Get current time
       uses: josStorer/get-current-time@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -43,14 +43,14 @@ jobs:
 
     # More info on options: https://github.com/conda-incubator/setup-miniconda
     - name: Cache conda
-        uses: actions/cache@v2
-        env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key:
-            ${{ runner.os }}-${{ runner.arch }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('devtools/conda-envs/mols.yml') }}
+      uses: actions/cache@v2
+      env:
+        # Increase this value to reset cache if etc/example-environment.yml has not changed
+        CACHE_NUMBER: 0
+      with:
+        path: ~/conda_pkgs_dir
+        key:
+          ${{ runner.os }}-${{ runner.arch }}-conda-${{ env.CACHE_NUMBER }}-${{ hashFiles('devtools/conda-envs/mols.yml') }}
 
     - name: Setup conda
       uses: conda-incubator/setup-miniconda@v2

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -42,13 +42,10 @@ jobs:
         ulimit -a
 
     # More info on the whole conda setup: https://github.com/conda-incubator/setup-miniconda
-    - name: Setup Mambaforge
+    - name: Setup Conda
       uses: conda-incubator/setup-miniconda@v2
       with:
-        miniforge-variant: Mambaforge
-        miniforge-version: latest
         activate-environment: mols_test
-        use-mamba: true
     # Get date for the cache key
     - name: Get current time
       uses: josStorer/get-current-time@v2
@@ -68,7 +65,7 @@ jobs:
           steps.current-time.outputs.month }}-${{ hashFiles('devtools/conda-envs/mols.yml') }}-${{ env.CACHE_NUMBER }}
     # Install environment from yaml file if cache-hit == false
     - name: Update conda env
-      run: mamba env update -n mols_test -f devtools/conda-envs/mols.yml
+      run: conda env update -n mols_test -f devtools/conda-envs/mols.yml
       if: steps.cache.outputs.cache-hit != 'true'
 
     - name: Install package

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -75,7 +75,7 @@ jobs:
     
     - name: Run tests
       run: |
-        pytest -v tests/
+        pytest -v --cov=molSimplify
         
     - name: Report Status
       # Slack notifications only on the main repo

--- a/.github/workflows/python-linter.yaml
+++ b/.github/workflows/python-linter.yaml
@@ -37,7 +37,7 @@ jobs:
       #uses: ravsamhq/notify-slack-action@v1
       uses: 8398a7/action-slack@v3
       with:
-        fields: repo,message,commit,author,action,eventName,ref,workflow,job,took
+        fields: message,commit,author,workflow,job,took
         status: ${{ job.status }}
       env:
         SLACK_WEBHOOK_URL: ${{secrets.SLACK_WEBHOOK}}


### PR DESCRIPTION
Following the example at https://github.com/conda-incubator/setup-miniconda a workflow for caching the conda environment is implemented (Saves about 10 minutes from each build using a 1.3 GB cache file). In this configuration the conda environment is only updated whenever the `mols.yml` file is changed or at the beginning of each new month.

Additional changes:
- bash is set as default shell instead of explicitly defining the shell for each job step
- Redundant/unchanging fields are removed from the slack notification