### PR TITLE
fix bug for compute_adj_matrix

### DIFF
--- a/molSimplify/Informatics/MOF/Linker_rotation.py
+++ b/molSimplify/Informatics/MOF/Linker_rotation.py
@@ -145,7 +145,7 @@ for elem in func_group:
     cell_v = np.array(cell_vector)
     cart_coords = fractional2cart(fcoords,cell_v)
     distance_mat = compute_distance_matrix3(cell_v,cart_coords) # distance matrix of all atoms
-    adj_matrix = compute_adj_matrix(distance_mat,allatomtypes) # from distance matrix and heuristics for bond distances, obtains connectivity information in the form of adjacency matrix (graph)
+    adj_matrix, _ = compute_adj_matrix(distance_mat,allatomtypes) # from distance matrix and heuristics for bond distances, obtains connectivity information in the form of adjacency matrix (graph)
     molcif.graph = adj_matrix.todense() # dense form of adjacency matrix / graph is saved to molcif object
 
 

--- a/molSimplify/Informatics/MOF/MOF_descriptors.py
+++ b/molSimplify/Informatics/MOF/MOF_descriptors.py
@@ -546,7 +546,7 @@ def get_MOF_descriptors(data, depth, path=False, xyzpath=False, graph_provided=F
     if not graph_provided: # Make the adjacency matrix.
         distance_mat = compute_distance_matrix3(cell_v,cart_coords)
         try:
-            adj_matrix,_=compute_adj_matrix(distance_mat,allatomtypes,wiggle_room)
+            adj_matrix, _ = compute_adj_matrix(distance_mat,allatomtypes,wiggle_room)
         except NotImplementedError:
             failure_str = f"Failed to featurize {name}: atomic overlap\n"
             full_names, full_descriptors = failure_response(path, failure_str)

--- a/molSimplify/Informatics/MOF/MOF_descriptors_alternate_functional.py
+++ b/molSimplify/Informatics/MOF/MOF_descriptors_alternate_functional.py
@@ -316,7 +316,7 @@ def get_MOF_descriptors(data, depth, path=False, xyzpath = False):
         return full_names, full_descriptors
     distance_mat = compute_distance_matrix2(cell_v,cart_coords)
     try:
-        adj_matrix=compute_adj_matrix(distance_mat,allatomtypes)
+        adj_matrix, _ = compute_adj_matrix(distance_mat,allatomtypes)
     except NotImplementedError:
         full_names = [0]
         full_descriptors = [0]

--- a/molSimplify/Informatics/MOF/MOF_descriptors_alternate_functional_2.py
+++ b/molSimplify/Informatics/MOF/MOF_descriptors_alternate_functional_2.py
@@ -317,7 +317,7 @@ def get_MOF_descriptors(data, depth, path=False, xyzpath = False):
         return full_names, full_descriptors
     distance_mat = compute_distance_matrix2(cell_v,cart_coords)
     try:
-        adj_matrix=compute_adj_matrix(distance_mat,allatomtypes)
+        adj_matrix, _ = compute_adj_matrix(distance_mat,allatomtypes)
     except NotImplementedError:
         full_names = [0]
         full_descriptors = [0]

--- a/molSimplify/Informatics/MOF/cluster_extraction.py
+++ b/molSimplify/Informatics/MOF/cluster_extraction.py
@@ -167,7 +167,7 @@ def get_MOF_descriptors(data, depth, path=False, xyzpath = False):
         return None, None
     distance_mat = pbc_funs.compute_distance_matrix2(cell_v, cart_coords)
     try:
-        adj_matrix = pbc_funs.compute_adj_matrix(distance_mat, allatomtypes)
+        adj_matrix, _ = pbc_funs.compute_adj_matrix(distance_mat, allatomtypes)
     except NotImplementedError:
         tmpstr = "Failed to featurize %s: atomic overlap\n" % (name)
         pbc_funs.write2file(path, "/FailedStructures.log", tmpstr)

--- a/molSimplify/Informatics/MOF/fragment_MOFs_for_pormake.py
+++ b/molSimplify/Informatics/MOF/fragment_MOFs_for_pormake.py
@@ -545,7 +545,7 @@ def make_MOF_fragments(data, depth, path=False, xyzpath = False):
         return None, None
     distance_mat = compute_distance_matrix2(cell_v,cart_coords)
     try:
-        adj_matrix, _ =compute_adj_matrix(distance_mat,allatomtypes)
+        adj_matrix, _ = compute_adj_matrix(distance_mat,allatomtypes)
     except NotImplementedError:
         tmpstr = "Failed to featurize %s: atomic overlap\n"%(name)
         write2file(path,"/FailedStructures.log",tmpstr)


### PR DESCRIPTION
A while back I modified `compute_adj_matrix` to return a second value in addition to the adjacency matrix. This is a breaking change wherever that function was called in other molSimplify files, since those files expected only one return value. I modified all cases where `compute_adj_matrix` was called in those functions, from something like `adj_matrix = compute_adj_matrix(distance_mat,allatomtypes)` to something like `adj_matrix, _ = compute_adj_matrix(distance_mat,allatomtypes)`, to address this issue.