### PR TITLE
assess whether can drop the line `setup_requires=[pytest-runner]` sin…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(name='molSimplify',
       install_requires=['numpy', 'scipy', 'scikit-learn',
                         'keras', 'tensorflow', 'pyyaml',
                         'pre-commit'],
-      setup_requires=['pytest-runner'],  # this may result some package conflict in local conda build. comment it out if needed.
       tests_require=['pytest'],
       include_package_data=True
       )


### PR DESCRIPTION
…ce we no longer use Travis CI