### PR TITLE
RMSD including initial alignment by principal moments of inertia

### DIFF
--- a/molSimplify/Classes/mol3D.py
+++ b/molSimplify/Classes/mol3D.py
@@ -2672,7 +2672,7 @@ class mol3D:
             pmom : np.array
                 3x1 array of the principal moments of inertia, in the provided Cartesian frame.
             P : np.array
-                Rotation matrix to rotate original molecule (after reordering using index_arr)
+                Rotation matrix to rotate original molecule
                 in order to have the axes correspond to the principal moments of inertia
                 Use by running atom.setcoords(P.dot(atom.coords())) for each atom
 

--- a/molSimplify/Classes/mol3D.py
+++ b/molSimplify/Classes/mol3D.py
@@ -2532,6 +2532,32 @@ class mol3D:
             if distance(cm, atom.coords()) > maxd:
                 maxd = distance(cm, atom.coords())
         return maxd
+    
+    def moments_of_inertia(self):
+        """
+        Determines the moments of inertia for the object, in the specified coordinates
+        (after centering about the center of mass)
+
+        Returns
+        -------
+            I : np.array
+                Moments of inertia tensor
+        """
+        I = np.zeros((3, 3))
+        #center about the center of mass
+        cm = self.centermass()
+        for atom in self.atoms:
+            atom.setcoords(np.array(atom.coords()) - cm)
+            I[0, 0] += atom.mass * (atom.coords()[1]**2 + atom.coords()[2]**2) #xx
+            I[1, 1] += atom.mass * (atom.coords()[0]**2 + atom.coords()[2]**2) #yy
+            I[2, 2] += atom.mass * (atom.coords()[0]**2 + atom.coords()[1]**2) #zz
+            I[0, 1] -= atom.mass * (atom.coords()[0] * atom.coords()[1]) #xy
+            I[1, 0] -= atom.mass * (atom.coords()[0] * atom.coords()[1]) #yx
+            I[0, 2] -= atom.mass * (atom.coords()[2] * atom.coords()[0]) #xz
+            I[2, 0] -= atom.mass * (atom.coords()[2] * atom.coords()[0]) #zx
+            I[1, 2] -= atom.mass * (atom.coords()[1] * atom.coords()[2]) #yz
+            I[2, 1] -= atom.mass * (atom.coords()[1] * atom.coords()[2]) #zy
+        return I
 
     def overlapcheck(self, mol, silence=False):
         """
@@ -2630,6 +2656,39 @@ class mol3D:
             if len(error_idx[i]) > 0:
                 molBOMat[error_idx[i].tolist()[0], error_idx[i].tolist()[1]] = 1
         return (molBOMat)
+    
+    def principal_moments_of_inertia(self, return_transform=False):
+        """
+        Returns the diagonalized moments of inertia tensor, and optionally the
+        matrices required to diagonalize this tensor.
+
+        Parameters
+        ----------
+            return_transform : bool
+                Flag for if the matrices used to diagonalize I should be returned.
+                Default is False.
+        Returns
+        -------
+            pmom : np.array
+                3x1 array of the principal moments of inertia, in the provided Cartesian frame.
+            P : np.array
+                Rotation matrix to rotate original molecule (after reordering using index_arr)
+                in order to have the axes correspond to the principal moments of inertia
+                Use by running atom.setcoords(P.dot(atom.coords())) for each atom
+
+        """
+        I = self.moments_of_inertia()
+        #diagonalize the moments of inertia
+        eigvals, eigvecs = np.linalg.eig(I)
+        D = np.linalg.inv(eigvecs) @ I @ eigvecs
+        pmom = np.diag(D)
+        #transformation for the original coordinates defined as inverse of eigenvectors
+        P = np.linalg.inv(eigvecs)
+
+        if return_transform:
+            return pmom, P
+        else:
+            return pmom
 
     def printxyz(self):
         """

--- a/molSimplify/Scripts/rmsd.py
+++ b/molSimplify/Scripts/rmsd.py
@@ -372,7 +372,8 @@ def reorder_distance(p_atoms, q_atoms, p_coord, q_coord):
 
 
 def rmsd_reorder_rotate(p_atoms, q_atoms, p_coord, q_coord,
-                        rotation="kabsch", reorder="hungarian"):
+                        rotation="kabsch", reorder="hungarian",
+                        translate=True):
     """Reorder and rotate for RMSD.
 
     Parameters
@@ -389,6 +390,10 @@ def rmsd_reorder_rotate(p_atoms, q_atoms, p_coord, q_coord,
             Rotation method. Default is kabsch.
         reorder : str, optional
             Reorder method. Default is hungarian.
+        translate : bool, optional
+            Whether or not the molecules should be translated
+            such that their centroid is at the origin.
+            Default is True.
 
     Returns
     -------
@@ -404,11 +409,11 @@ def rmsd_reorder_rotate(p_atoms, q_atoms, p_coord, q_coord,
         print(("Warning: Atom types do not match!",
                np.unique(p_atoms), np.unique(q_atoms)))
         return 1000
-
-    p_cent = centroid(p_coord)
-    q_cent = centroid(q_coord)
-    p_coord -= p_cent
-    q_coord -= q_cent
+    if translate:
+        p_cent = centroid(p_coord)
+        q_cent = centroid(q_coord)
+        p_coord -= p_cent
+        q_coord -= q_cent
 
     # set rotation method
     if rotation.lower() == "kabsch":
@@ -472,6 +477,77 @@ def rigorous_rmsd(mol1, mol2, rotation: str = "kabsch",
                                       rotation=rotation, reorder=reorder)
     return result_rmsd
 
+def align_rmsd(mol1, mol2, rotation: str = "kabsch",
+               reorder: str = "hungarian") -> float:
+    """
+    Computes the RMSD between 2 mol objects after:
+    - translating them both such that the center of mass is at the origin
+    - projecting the coordinates onto the principal axes
+    - reordering x, y, z such that Ixx < Iyy < Izz
+
+    Parameters
+    ----------
+        mol1 : mol3D
+            mol3D instance of initial molecule.
+        mol2 : np.mol3D
+            mol3D instance of final molecule.
+        rotation : str, optional
+            Rotation method. Default is kabsch.
+        reorder : str, optional
+            Reorder method. Default is hungarian.
+
+    Returns
+    -------
+        rmsd : float
+            Resulting RMSD from aligning and rotating.
+    """
+    
+    mol1_atoms = mol1.symvect()
+    cm1 = mol1.centermass()
+    pmom1, P1 = mol1.principal_moments_of_inertia(return_transform=True)
+    for atom in mol1.atoms:
+        atom.setcoords(np.array(atom.coords()) - cm1) #center
+        atom.setcoords(P1.dot(atom.coords())) #project onto principal moments
+        atom.setcoords(np.array(atom.coords())[np.argsort(pmom1)].flatten())
+    mol1_coords = mol1.coordsvect()
+
+    #note: the above aligns the largest moment of inertia with z, the smallest with x
+    #does not account for whether it is aligned with + or - part of an axis
+    #so, have to allow for 180deg rotations and reflections as well
+    
+    rmsd = np.inf
+    x_rot = np.array([[1, 0, 0], [0, -1, 0], [0, 0, -1]]) #180 about x
+    y_rot = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, -1]]) #180 about y
+    z_rot = np.array([[-1, 0, 0], [0, -1, 0], [0, 0, 1]]) #180 about z
+    x_ref = np.array([[-1, 0, 0], [0, 1, 0], [0, 0, 1]]) #reflect about yz
+    y_ref = np.array([[1, 0, 0], [0, -1, 0], [0, 0, 1]]) #reflect about xz
+    z_ref = np.array([[1, 0, 0], [0, 1, 0], [0, 0, -1]]) #reflect about xy
+    a_ref = np.array([[-1, 0, 0], [0, -1, 0], [0, 0, -1]]) #reflect all 3 
+    transformations = [
+        np.eye(3), #no change
+        x_rot, y_rot, z_rot,
+        x_ref, y_ref, z_ref, a_ref
+    ]
+    mol2_atoms = mol2.symvect()
+    cm2 = mol2.centermass()
+    pmom2, P2 = mol2.principal_moments_of_inertia(return_transform=True)
+    for atom in mol2.atoms:
+        atom.setcoords(np.array(atom.coords()) - cm2) #center
+        atom.setcoords(P2.dot(atom.coords())) #project onto principal moments
+        atom.setcoords(np.array(atom.coords())[np.argsort(pmom2)].flatten())
+    for transformation in transformations:
+        for atom in mol2.atoms:
+            atom.setcoords(transformation @ np.array(atom.coords()))
+        mol2_coords = mol2.coordsvect()
+        #revert rotations
+        for atom in mol2.atoms:
+            atom.setcoords(np.linalg.inv(transformation) @ np.array(atom.coords()))
+
+        result_rmsd = rmsd_reorder_rotate(mol1_atoms, mol2_atoms, mol1_coords, mol2_coords,
+                                          rotation=rotation, reorder=reorder, translate=True)
+        if result_rmsd < rmsd:
+            rmsd = result_rmsd
+    return rmsd
 
 def test_case():
     p_atoms = np.array(["N", "H", "H", "H"])

--- a/molSimplify/Scripts/rmsd.py
+++ b/molSimplify/Scripts/rmsd.py
@@ -484,6 +484,8 @@ def align_rmsd(mol1, mol2, rotation: str = "kabsch",
     - translating them both such that the center of mass is at the origin
     - projecting the coordinates onto the principal axes
     - reordering x, y, z such that Ixx < Iyy < Izz
+    (will allow for 180degree rotations about x, y, z, as well as 
+    reflections about the xy, xz, yz, and all three of those planes)
 
     Parameters
     ----------
@@ -508,6 +510,7 @@ def align_rmsd(mol1, mol2, rotation: str = "kabsch",
     for atom in mol1.atoms:
         atom.setcoords(np.array(atom.coords()) - cm1) #center
         atom.setcoords(P1.dot(atom.coords())) #project onto principal moments
+        #sort the coordinates so that the largest princiipal moment is first
         atom.setcoords(np.array(atom.coords())[np.argsort(pmom1)].flatten())
     mol1_coords = mol1.coordsvect()
 
@@ -534,12 +537,13 @@ def align_rmsd(mol1, mol2, rotation: str = "kabsch",
     for atom in mol2.atoms:
         atom.setcoords(np.array(atom.coords()) - cm2) #center
         atom.setcoords(P2.dot(atom.coords())) #project onto principal moments
+        #sort the coordinates so that the largest princiipal moment is first
         atom.setcoords(np.array(atom.coords())[np.argsort(pmom2)].flatten())
     for transformation in transformations:
         for atom in mol2.atoms:
             atom.setcoords(transformation @ np.array(atom.coords()))
         mol2_coords = mol2.coordsvect()
-        #revert rotations
+        #revert transformations
         for atom in mol2.atoms:
             atom.setcoords(np.linalg.inv(transformation) @ np.array(atom.coords()))
 


### PR DESCRIPTION
Added in functions to compute moments of inertia and principal moments of inertia for mol3D objects. Also added in an RMSD function that performs `rigorous_rmsd` logic (reorders the atoms based on pairwise distances and then rotates the molecules to align) after aligning the molecules about their principal moments of inertia, which should be more robust to errors in improper assignments.