### PR TITLE
Adding Continuous Shape Measures to Geometry Classification

### DIFF
--- a/molSimplify/Classes/mol3D.py
+++ b/molSimplify/Classes/mol3D.py
@@ -5879,7 +5879,7 @@ class mol3D:
                 cshm = self.continuous_shape_measure(all_polyhedra[geotype])
                 summary.update({geotype: {'rmsd': rmsd_calc, 'max_single_atom_deviation': max_dist, 'continuous_shape_measure': cshm}})
             else:
-                summary.update({geotype: [rmsd_calc, max_dist]})
+                summary.update({geotype: {'rmsd': rmsd_calc, 'max_single_atom_deviation': max_dist}})
 
         close_rmsds = False
         current_rmsd, geometry = max_dev, "unknown"


### PR DESCRIPTION
Added in an optional flag to the `get_geometry_type_distance` method in the `mol3D` class. This allows for a more straightforward evaluation of the deviation between a structure and an ideal structure.