### PR TITLE
Bug fix in readfrommol2

### DIFF
--- a/molSimplify/Classes/mol3D.py
+++ b/molSimplify/Classes/mol3D.py
@@ -2853,6 +2853,8 @@ class mol3D:
                 read_atoms = False
             if '<TRIPOS>SUBSTRUCTURE' in line:
                 read_bonds = False
+            if '<TRIPOS>UNITY_ATOM_ATTR' in line:
+                read_atoms = False
             if read_atoms:
                 s_line = line.split()
                 # Check redundancy in Chemical Symbols


### PR DESCRIPTION
Fixed bug in readfrommol2() which fails when mol2 string includes "@<TRIPOS>UNITY_ATOM_ATTR"