### PR TITLE
responding to recent readthedocs deprecation 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,3 +15,5 @@ python:
 sphinx:
   builder: html
   fail_on_warning: true
+  # Path to the Sphinx configuration file.
+  configuration: docs/source/conf.py


### PR DESCRIPTION
https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/
"Deprecation of projects using Sphinx or MkDocs without an explicit configuration file"