### PR TITLE
Resolving Issue #273

### DIFF
--- a/molSimplify/Classes/dft_obs.py
+++ b/molSimplify/Classes/dft_obs.py
@@ -6,8 +6,8 @@
 #  Dpt of Chemical Engineering, MIT
 
 from molSimplify.Informatics.lacRACAssemble import (
-    generate_all_ligand_autocorrelations,
-    generate_all_ligand_deltametrics,
+    generate_all_ligand_autocorrelations_lac,
+    generate_all_ligand_deltametrics_lac,
     generate_full_complex_autocorrelations,
     generate_metal_autocorrelations,
     generate_metal_deltametrics,
@@ -57,7 +57,7 @@ class dft_observation:
         print(('after adding misc descriptors... ' +
                str(len(self.descriptor_names))))
         if self.coord == 6:  # oct only
-            results_dictionary = generate_all_ligand_autocorrelations(
+            results_dictionary = generate_all_ligand_autocorrelations_lac(
                 self.mol, depth=3, loud=loud, flag_name=flag_name)
             self.append_descriptors(
                 results_dictionary['colnames'], results_dictionary['result_ax_full'], 'f', 'ax')
@@ -70,7 +70,7 @@ class dft_observation:
                     results_dictionary['colnames'], results_dictionary['result_ax_con'], 'lc', 'ax')
                 self.append_descriptors(
                     results_dictionary['colnames'], results_dictionary['result_eq_con'], 'lc', 'eq')
-                results_dictionary = generate_all_ligand_deltametrics(
+                results_dictionary = generate_all_ligand_deltametrics_lac(
                     self.mol, depth=3, loud=True, flag_name=flag_name)
                 self.append_descriptors(
                     results_dictionary['colnames'], results_dictionary['result_ax_con'], 'D_lc', 'ax')

--- a/molSimplify/Informatics/RACassemble.py
+++ b/molSimplify/Informatics/RACassemble.py
@@ -26,7 +26,7 @@ from molSimplify.Informatics.lacRACAssemble import (
     generate_metal_deltametric_derivatives,
     generate_metal_deltametrics,
     generate_metal_ox_autocorrelation_derivatives,
-    generate_metal_ox_autocorrelations,    
+    generate_metal_ox_autocorrelations,
     generate_metal_ox_deltametric_derivatives,
     generate_metal_ox_deltametrics,
     )

--- a/molSimplify/Informatics/RACassemble.py
+++ b/molSimplify/Informatics/RACassemble.py
@@ -17,18 +17,18 @@ from molSimplify.Informatics.autocorrelation import (
     generate_all_ligand_autocorrelations,
     generate_all_ligand_deltametric_derivatives,
     generate_all_ligand_deltametrics,
+    )
+from molSimplify.Informatics.lacRACAssemble import (
+    generate_full_complex_autocorrelation_derivatives,
+    generate_full_complex_autocorrelations,
     generate_metal_autocorrelation_derivatives,
     generate_metal_autocorrelations,
     generate_metal_deltametric_derivatives,
     generate_metal_deltametrics,
     generate_metal_ox_autocorrelation_derivatives,
-    generate_metal_ox_autocorrelations,
+    generate_metal_ox_autocorrelations,    
     generate_metal_ox_deltametric_derivatives,
     generate_metal_ox_deltametrics,
-    )
-from molSimplify.Informatics.lacRACAssemble import (
-    generate_full_complex_autocorrelation_derivatives,
-    generate_full_complex_autocorrelations,
     )
 from molSimplify.Informatics.misc_descriptors import generate_all_ligand_misc
 from molSimplify.Informatics.rac155_geo import rac155_list

--- a/molSimplify/Informatics/autocorrelation.py
+++ b/molSimplify/Informatics/autocorrelation.py
@@ -18,6 +18,14 @@ from molSimplify.Informatics.lacRACAssemble import (
     full_autocorrelation_derivative,
     generate_full_complex_autocorrelation_derivatives,
     generate_full_complex_autocorrelations,
+    generate_metal_autocorrelation_derivatives,
+    generate_metal_autocorrelations,
+    generate_metal_deltametric_derivatives,
+    generate_metal_deltametrics,
+    generate_metal_ox_autocorrelation_derivatives,
+    generate_metal_ox_autocorrelations,    
+    generate_metal_ox_deltametric_derivatives,
+    generate_metal_ox_deltametrics,
     get_metal_index,
     metal_only_autocorrelation,
     metal_only_autocorrelation_derivative,
@@ -882,63 +890,6 @@ def generate_all_ligand_deltametric_derivatives(mol, loud, depth=4, name=False, 
     return results_dictionary
 
 
-def generate_metal_autocorrelations(mol, loud, depth=4, oct=True, flag_name=False,
-                                    modifier=False, NumB=False, Gval=False):
-    # oct - bool, if complex is octahedral, will use better bond checks
-    result = list()
-    colnames = []
-    allowed_strings = ['electronegativity', 'nuclear_charge', 'ident', 'topology', 'size']
-    labels_strings = ['chi', 'Z', 'I', 'T', 'S']
-    if Gval:
-        allowed_strings += ['group_number']
-        labels_strings += ['Gval']
-    if NumB:
-        allowed_strings += ["num_bonds"]
-        labels_strings += ["NumB"]
-    for ii, properties in enumerate(allowed_strings):
-        metal_ac = metal_only_autocorrelation(mol, properties, depth, oct=oct, modifier=modifier)
-        this_colnames = []
-        for i in range(0, depth + 1):
-            this_colnames.append(labels_strings[ii] + '-' + str(i))
-        colnames.append(this_colnames)
-        result.append(metal_ac)
-    if flag_name:
-        results_dictionary = {'colnames': colnames, 'results_mc_ac': result}
-    else:
-        results_dictionary = {'colnames': colnames, 'results': result}
-    return results_dictionary
-
-
-def generate_metal_autocorrelation_derivatives(mol, loud, depth=4, oct=True, flag_name=False,
-                                               modifier=False, NumB=False, Gval=False):
-    # oct - bool, if complex is octahedral, will use better bond checks
-    result = None
-    colnames = []
-    allowed_strings = ['electronegativity', 'nuclear_charge', 'ident', 'topology', 'size']
-    labels_strings = ['chi', 'Z', 'I', 'T', 'S']
-    if Gval:
-        allowed_strings += ['group_number']
-        labels_strings += ['Gval']
-    if NumB:
-        allowed_strings += ["num_bonds"]
-        labels_strings += ["NumB"]
-    for ii, properties in enumerate(allowed_strings):
-        metal_ac_der = metal_only_autocorrelation_derivative(mol, properties, depth, oct=oct, modifier=modifier)
-        for i in range(0, depth + 1):
-            colnames.append(['d' + labels_strings[ii] + '-' + str(i) + '/d' + labels_strings[ii] + str(j) for j in
-                             range(0, mol.natoms)])
-
-        if result is None:
-            result = metal_ac_der
-        else:
-            result = np.row_stack([result, metal_ac_der])
-    if flag_name:
-        results_dictionary = {'colnames': colnames, 'results_mc_ac': result}
-    else:
-        results_dictionary = {'colnames': colnames, 'results': result}
-    return results_dictionary
-
-
 def generate_multimetal_autocorrelations(mol, loud, depth=4, oct=True, flag_name=False, polarizability=False, Gval=False):
     # oct - bool, if complex is octahedral, will use better bond checks
     result = list()
@@ -985,71 +936,6 @@ def generate_multiatom_autocorrelations(mol, loud, depth=4, oct=True, flag_name=
     return results_dictionary
 
 
-def generate_metal_ox_autocorrelations(oxmodifier, mol, loud, depth=4, oct=True, flag_name=False):
-    # # oxmodifier - dict, used to modify prop vector (e.g. for adding
-    # #             ONLY used with  ox_nuclear_charge    ox or charge)
-    # #              {"Fe":2, "Co": 3} etc, normally only 1 metal...
-    #   oct - bool, if complex is octahedral, will use better bond checks
-    result = list()
-    colnames = []
-    metal_ox_ac = metal_only_autocorrelation(mol, 'ox_nuclear_charge', depth, oct=oct, modifier=oxmodifier)
-    this_colnames = []
-    for i in range(0, depth + 1):
-        this_colnames.append('O' + '-' + str(i))
-    colnames.append(this_colnames)
-    result.append(metal_ox_ac)
-    results_dictionary = {'colnames': colnames, 'results': result}
-    return results_dictionary
-
-
-def generate_metal_ox_autocorrelation_derivatives(oxmodifier, mol, loud, depth=4, oct=True, flag_name=False):
-    # # oxmodifier - dict, used to modify prop vector (e.g. for adding
-    # #             ONLY used with  ox_nuclear_charge    ox or charge)
-    # #              {"Fe":2, "Co": 3} etc, normally only 1 metal...
-    #   oct - bool, if complex is octahedral, will use better bond checks
-    result = None
-    colnames = []
-    metal_ox_ac = metal_only_autocorrelation_derivative(mol, 'ox_nuclear_charge', depth, oct=oct, modifier=oxmodifier)
-    for i in range(0, depth + 1):
-        colnames.append(['d' + 'O' + '-' + str(i) + '/d' + 'O' + str(j) for j in range(0, mol.natoms)])
-    result = metal_ox_ac
-    results_dictionary = {'colnames': colnames, 'results': result}
-    return results_dictionary
-
-
-def generate_metal_ox_deltametrics(oxmodifier, mol, loud, depth=4, oct=True, flag_name=False):
-    # # oxmodifier - dict, used to modify prop vector (e.g. for adding
-    # #             ONLY used with  ox_nuclear_charge    ox or charge)
-    # #              {"Fe":2, "Co": 3} etc, normally only 1 metal...
-    #   oct - bool, if complex is octahedral, will use better bond checks
-    result = list()
-    colnames = []
-    metal_ox_ac = metal_only_deltametric(mol, 'ox_nuclear_charge', depth, oct=oct, modifier=oxmodifier)
-    this_colnames = []
-    for i in range(0, depth + 1):
-        this_colnames.append('O' + '-' + str(i))
-    colnames.append(this_colnames)
-    result.append(metal_ox_ac)
-    results_dictionary = {'colnames': colnames, 'results': result}
-    return results_dictionary
-
-
-def generate_metal_ox_deltametric_derivatives(oxmodifier, mol, loud, depth=4, oct=True, flag_name=False):
-    # # oxmodifier - dict, used to modify prop vector (e.g. for adding
-    # #             ONLY used with  ox_nuclear_charge    ox or charge)
-    # #              {"Fe":2, "Co": 3} etc, normally only 1 metal...
-    #   oct - bool, if complex is octahedral, will use better bond checks
-    result = list()
-    colnames = []
-    metal_ox_ac = metal_only_deltametric_derivative(mol, 'ox_nuclear_charge', depth, oct=oct, modifier=oxmodifier)
-    for i in range(0, depth + 1):
-        colnames.append(['d' + 'O' + '-' + str(i) + '/d' + 'O' + str(j) for j in range(0, mol.natoms)])
-
-    result = metal_ox_ac
-    results_dictionary = {'colnames': colnames, 'results': result}
-    return results_dictionary
-
-
 def generate_metal_ox_eff_autocorrelations(oxmodifier, mol, loud, depth=4, oct=True, flag_name=False):
     # # oxmodifier - dict, used to modify prop vector (e.g. for adding
     # #             ONLY used with  ox_nuclear_charge    ox or charge)
@@ -1081,62 +967,6 @@ def generate_metal_ox_eff_deltametrics(oxmodifier, mol, loud, depth=4, oct=True,
     colnames.append(this_colnames)
     result.append(metal_ox_ac)
     results_dictionary = {'colnames': colnames, 'results': result}
-    return results_dictionary
-
-
-def generate_metal_deltametrics(mol, loud, depth=4, oct=True, flag_name=False,
-                                modifier=False, NumB=False, Gval=False):
-    #   oct - bool, if complex is octahedral, will use better bond checks
-    result = list()
-    colnames = []
-    allowed_strings = ['electronegativity', 'nuclear_charge', 'ident', 'topology', 'size']
-    labels_strings = ['chi', 'Z', 'I', 'T', 'S']
-    if Gval:
-        allowed_strings += ['group_number']
-        labels_strings += ['Gval']
-    if NumB:
-        allowed_strings += ["num_bonds"]
-        labels_strings += ["NumB"]
-    for ii, properties in enumerate(allowed_strings):
-        metal_ac = metal_only_deltametric(mol, properties, depth, oct=oct, modifier=modifier)
-        this_colnames = []
-        for i in range(0, depth + 1):
-            this_colnames.append(labels_strings[ii] + '-' + str(i))
-        colnames.append(this_colnames)
-        result.append(metal_ac)
-    if flag_name:
-        results_dictionary = {'colnames': colnames, 'results_mc_del': result}
-    else:
-        results_dictionary = {'colnames': colnames, 'results': result}
-    return results_dictionary
-
-
-def generate_metal_deltametric_derivatives(mol, loud, depth=4, oct=True, flag_name=False,
-                                           modifier=False, NumB=False, Gval=False):
-    #   oct - bool, if complex is octahedral, will use better bond checks
-    result = None
-    colnames = []
-    allowed_strings = ['electronegativity', 'nuclear_charge', 'ident', 'topology', 'size']
-    labels_strings = ['chi', 'Z', 'I', 'T', 'S']
-    if Gval:
-        allowed_strings += ['group_number']
-        labels_strings += ['Gval']
-    if NumB:
-        allowed_strings += ["num_bonds"]
-        labels_strings += ["NumB"]
-    for ii, properties in enumerate(allowed_strings):
-        metal_ac_der = metal_only_deltametric_derivative(mol, properties, depth, oct=oct, modifier=modifier)
-        for i in range(0, depth + 1):
-            colnames.append(['d' + labels_strings[ii] + '-' + str(i) + '/d' + labels_strings[ii] + str(j) for j in
-                             range(0, mol.natoms)])
-        if result is None:
-            result = metal_ac_der
-        else:
-            result = np.row_stack([result, metal_ac_der])
-    if flag_name:
-        results_dictionary = {'colnames': colnames, 'results_mc_del': result}
-    else:
-        results_dictionary = {'colnames': colnames, 'results': result}
     return results_dictionary
 
 

--- a/molSimplify/Informatics/autocorrelation.py
+++ b/molSimplify/Informatics/autocorrelation.py
@@ -23,7 +23,7 @@ from molSimplify.Informatics.lacRACAssemble import (
     generate_metal_deltametric_derivatives,
     generate_metal_deltametrics,
     generate_metal_ox_autocorrelation_derivatives,
-    generate_metal_ox_autocorrelations,    
+    generate_metal_ox_autocorrelations,
     generate_metal_ox_deltametric_derivatives,
     generate_metal_ox_deltametrics,
     get_metal_index,

--- a/molSimplify/Informatics/lacRACAssemble.py
+++ b/molSimplify/Informatics/lacRACAssemble.py
@@ -6,6 +6,9 @@
 # ####### Defines methods for assembling    ###############
 # #######     RACs from lists of ligands    ###############
 # #########################################################
+
+# lac: ligand assign consistent
+
 from __future__ import print_function
 import numpy as np
 from molSimplify.Classes.ligand import (
@@ -123,7 +126,7 @@ def get_descriptor_vector(this_complex, custom_ligand_dict=False,
                                                        results_dictionary['results'],
                                                        'f', 'all')
     # # ligand ACs
-    results_dictionary = generate_all_ligand_autocorrelations(this_complex, depth=depth,
+    results_dictionary = generate_all_ligand_autocorrelations_lac(this_complex, depth=depth,
                                                               loud=False, flag_name=False,
                                                               custom_ligand_dict=custom_ligand_dict,
                                                               NumB=NumB, Gval=Gval, use_dist=use_dist,
@@ -148,7 +151,7 @@ def get_descriptor_vector(this_complex, custom_ligand_dict=False,
                                                        results_dictionary['result_eq_con'],
                                                        'lc', 'eq')
 
-    results_dictionary = generate_all_ligand_deltametrics(this_complex, depth=depth, loud=False,
+    results_dictionary = generate_all_ligand_deltametrics_lac(this_complex, depth=depth, loud=False,
                                                           custom_ligand_dict=custom_ligand_dict,
                                                           NumB=NumB, Gval=Gval, use_dist=use_dist,
                                                           size_normalize=size_normalize,
@@ -275,7 +278,7 @@ def get_descriptor_derivatives(this_complex, custom_ligand_dict=False, ox_modifi
                                                                                         'f', 'all')
     # ligand ACs
     # print('getting ligand AC derivatives')
-    results_dictionary = generate_all_ligand_autocorrelation_derivatives(this_complex, depth=depth, loud=False,
+    results_dictionary = generate_all_ligand_autocorrelation_derivatives_lac(this_complex, depth=depth, loud=False,
                                                                          custom_ligand_dict=custom_ligand_dict)
     descriptor_derivative_names, descriptor_derivatives = append_descriptor_derivatives(descriptor_derivative_names,
                                                                                         descriptor_derivatives,
@@ -297,7 +300,7 @@ def get_descriptor_derivatives(this_complex, custom_ligand_dict=False, ox_modifi
                                                                                         results_dictionary['colnames'],
                                                                                         results_dictionary['result_eq_con'],
                                                                                         'lc', 'eq')
-    results_dictionary = generate_all_ligand_deltametric_derivatives(this_complex, depth=depth, loud=False,
+    results_dictionary = generate_all_ligand_deltametric_derivatives_lac(this_complex, depth=depth, loud=False,
                                                                      custom_ligand_dict=custom_ligand_dict)
     descriptor_derivative_names, descriptor_derivatives = append_descriptor_derivatives(descriptor_derivative_names,
                                                                                         descriptor_derivatives,
@@ -1427,7 +1430,7 @@ def generate_all_ligand_misc(mol, loud, custom_ligand_dict=False, smiles_charge=
     return results_dictionary
 
 
-def generate_all_ligand_autocorrelations(mol, loud, depth=4, flag_name=False,
+def generate_all_ligand_autocorrelations_lac(mol, loud, depth=4, flag_name=False,
                                          custom_ligand_dict=False, NumB=False, Gval=False,
                                          use_dist=False, size_normalize=False, MRdiag_dict={}):
     """
@@ -1557,7 +1560,7 @@ def generate_all_ligand_autocorrelations(mol, loud, depth=4, flag_name=False,
     return results_dictionary
 
 
-def generate_all_ligand_autocorrelation_derivatives(mol, loud, depth=4, flag_name=False,
+def generate_all_ligand_autocorrelation_derivatives_lac(mol, loud, depth=4, flag_name=False,
                                                     custom_ligand_dict=False, NumB=False, Gval=False):
     """
     Utility for generating all ligand-based autocorrelation derivatives for a complex.
@@ -1683,7 +1686,7 @@ def generate_all_ligand_autocorrelation_derivatives(mol, loud, depth=4, flag_nam
     return results_dictionary
 
 
-def generate_all_ligand_deltametrics(mol, loud, depth=4, flag_name=False,
+def generate_all_ligand_deltametrics_lac(mol, loud, depth=4, flag_name=False,
                                      custom_ligand_dict=False, NumB=False, Gval=False,
                                      use_dist=False, size_normalize=False, MRdiag_dict={}):
     """
@@ -1787,7 +1790,7 @@ def generate_all_ligand_deltametrics(mol, loud, depth=4, flag_name=False,
     return results_dictionary
 
 
-def generate_all_ligand_deltametric_derivatives(mol, loud, depth=4, flag_name=False,
+def generate_all_ligand_deltametric_derivatives_lac(mol, loud, depth=4, flag_name=False,
                                                 custom_ligand_dict=False, NumB=False, Gval=False):
     """
     Utility for generating all ligand-based deltametric derivatives for a complex.
@@ -1895,6 +1898,7 @@ def generate_metal_autocorrelations(mol, loud, depth=4, oct=True, flag_name=Fals
             Depth of RACs to calculate, by default 4.
         oct : bool, optional
             Use octahedral criteria for structure evaluation, by default True.
+            If complex is octahedral, will use better bond checks.
         flag_name : bool, optional
             Shift RAC names slightly, by default False.
         modifier : bool, optional
@@ -1965,6 +1969,7 @@ def generate_metal_autocorrelation_derivatives(mol, loud, depth=4, oct=True, fla
             Depth of RACs to calculate, by default 4.
         oct : bool, optional
             Use octahedral criteria for structure evaluation, by default True.
+            If complex is octahedral, will use better bond checks.
         flag_name : bool, optional
             Shift RAC names slightly, by default False.
         modifier : bool, optional
@@ -2027,6 +2032,7 @@ def generate_metal_deltametrics(mol, loud, depth=4, oct=True, flag_name=False,
             Depth of RACs to calculate, by default 4.
         oct : bool, optional
             Use octahedral criteria for structure evaluation, by default True.
+            If complex is octahedral, will use better bond checks.
         flag_name : bool, optional
             Shift RAC names slightly, by default False.
         modifier : bool, optional
@@ -2098,6 +2104,7 @@ def generate_metal_deltametric_derivatives(mol, loud, depth=4, oct=True, flag_na
             Depth of RACs to calculate, by default 4.
         oct : bool, optional
             Use octahedral criteria for structure evaluation, by default True.
+            If complex is octahedral, will use better bond checks.
         flag_name : bool, optional
             Shift RAC names slightly, by default False.
         modifier : bool, optional


### PR DESCRIPTION
Resolved redundancy issues between autocorrelation.py and lacRACassemble.py
Specifically looked at these functions:
1. generate_all_ligand_autocorrelations
2. generate_all_ligand_autocorrelation_derivatives
3. generate_all_ligand_deltametrics
4. generate_all_ligand_deltametric_derivatives
5. generate_metal_autocorrelations
6. generate_metal_autocorrelation_derivatives
7. generate_metal_deltametrics
8. generate_metal_deltametric_derivatives
9. generate_metal_ox_autocorrelations
10. generate_metal_ox_autocorrelation_derivatives
11. generate_metal_ox_deltametrics
12. generate_metal_ox_deltametric_derivatives

In most cases, deleted from autocorrelation.py and kept in lacRACassemble.py
In some cases, when function was different between autocorrelation.py and lacRACassemble.py, I renamed the function in lacRACassemble.py (added a _lac suffix to function name). Functions: generate_all_ligand_autocorrelations_lac, generate_all_ligand_autocorrelation_derivatives_lac, generate_all_ligand_deltametrics_lac, generate_all_ligand_deltametric_derivatives_lac