### PR TITLE
Update mol2D.py

### DIFF
--- a/molSimplify/Classes/mol2D.py
+++ b/molSimplify/Classes/mol2D.py
@@ -161,7 +161,7 @@ class Mol2D(nx.Graph):
         # of weisfeiler_lehman_graph_hash
         # https://github.com/networkx/networkx/pull/4946#issuecomment-914623654
         assert version.parse(nx.__version__) >= version.parse("2.7")
-        return nx.weisfeiler_lehman_graph_hash(self, node_attr="symbol")
+        return nx.weisfeiler_lehman_graph_hash(self, node_attr="symbol", iterations = 5)
 
     def graph_hash_edge_attr(self) -> str:
         """Calculates the edge attributed graph hash of the molecule.
@@ -193,7 +193,7 @@ class Mol2D(nx.Graph):
             G.edges[i, j]["label"] = "".join(sorted([G.nodes[i]["symbol"],
                                                      G.nodes[j]["symbol"]]))
 
-        return nx.weisfeiler_lehman_graph_hash(G, edge_attr="label")
+        return nx.weisfeiler_lehman_graph_hash(G, edge_attr="label", iterations = 5)
 
     def graph_determinant(self, return_string: bool = True) -> Union[str, float]:
         """Calculates the molecular graph determinant.


### PR DESCRIPTION
Hot fix for an error that would cause large similar molecules to have identical hashes.