### PR TITLE
removed redundant function call

### DIFF
--- a/devtools/conda-envs/mols.yml
+++ b/devtools/conda-envs/mols.yml
@@ -29,4 +29,5 @@ dependencies:
   #- hyperopt
   # QM interfaces
   - xtb <6.7
+  - libgcc <15
   #- psi4::psi4

--- a/molSimplify/Classes/mol3D.py
+++ b/molSimplify/Classes/mol3D.py
@@ -1741,8 +1741,6 @@ class mol3D:
         # Get BO matrix if exits:
         obConversion = openbabel.OBConversion()
         obConversion.SetInFormat('mol2')
-        if not len(self.graph):
-            self.createMolecularGraph()
         if self.bo_dict:
             mol2string = self.writemol2('temporary', writestring=True,
                                         ignoreX=ignoreX)

--- a/molSimplify/Scripts/structgen.py
+++ b/molSimplify/Scripts/structgen.py
@@ -895,7 +895,7 @@ def xtb_opt(ff: str, mol: mol3D, connected: List[int], constopt: int,
         # number of steps is just restricted to the same maximum used in
         # adaptive mode: 20*50 = 1000
         nsteps = 1000
-    # Initialize defailed input file with optimization parameters.
+    # Initialize detailed input file with optimization parameters.
     input_lines = ['$opt\n', f'maxcycle={nsteps}\n']
     if inertial:
         # engine=inertial is selected in cases if the generation of approximate


### PR DESCRIPTION
In the mol3D method `convert2OBMol2`, since `populateBOMatrix` is always called with `set_bo_mat=True`, there is no need to call `createMolecularGraph` beforehand. The graph attribute will be set by `populateBOMatrix` and will be guaranteed consistent with `bo_dict`.