### PR TITLE
removing get_structures since it is deprecated

### DIFF
--- a/molSimplify/Informatics/MOF/MOF_descriptors.py
+++ b/molSimplify/Informatics/MOF/MOF_descriptors.py
@@ -74,8 +74,8 @@ def get_primitive(data_path, write_path, occupancy_tolerance=1):
     None
 
     """
-    from pymatgen.io.cif import parse_structures
-    s = parse_structures(data_path, occupancy_tolerance=occupancy_tolerance, primitive=True)[0]
+    from pymatgen.io.cif import CifParser
+    s = CifParser(data_path, occupancy_tolerance=occupancy_tolerance).parse_structures(primitive=True)[0]
     sprim = s.get_primitive_structure()
     sprim.to(filename=write_path, fmt="cif")  # Output structure to a file.
 

--- a/molSimplify/Informatics/MOF/cluster_extraction.py
+++ b/molSimplify/Informatics/MOF/cluster_extraction.py
@@ -22,8 +22,8 @@ import networkx as nx
 
 
 def get_primitive(data_path, write_path):
-    from pymatgen.io.cif import parse_structures
-    s = parse_structures(data_path, occupancy_tolerance=1, primitive=True)[0]
+    from pymatgen.io.cif import CifParser
+    s = CifParser(data_path, occupancy_tolerance=1).parse_structures(primitive=True)[0]
     sprim = s.get_primitive_structure()
     sprim.to(filename=write_path, fmt="cif")
 


### PR DESCRIPTION
Reacting to this warning from pymatgen
```
FutureWarning: get_structures is deprecated; use parse_structures in pymatgen.io.cif instead.
The only difference is that primitive defaults to False in the new parse_structures method.So parse_structures(primitive=True) is equivalent to the old behavior of get_structures().
  s = CifParser(data_path, occupancy_tolerance=occupancy_tolerance).get_structures()[0]
```