### PR TITLE
test_ligand_assign_consistent: assert exact eq order, drop sorted com…

### DIFF
--- a/tests/test_ligand_assign_consistent.py
+++ b/tests/test_ligand_assign_consistent.py
@@ -15,25 +15,21 @@ def test_six_monodentate(resource_path_root):
                                                    ligcons)
     # Expecting:
     # ax_ligands: ['water', 'carbonyl']
-    # eq_ligands: ['hydrogensulfide', 'ammonia', 'hydrocyanide', 'formaldehyde']
-    # (equatorial order can vary; compare sorted by formula)
+    # eq_ligands: ['formaldehyde', 'hydrocyanide', 'ammonia', 'hydrogensulfide']
+    # (equatorial order is deterministic: formula-sorted then trans-permuted in ligand_assign_consistent)
 
     ax_formulas = [lig.mol.make_formula(latex=False) for lig in ax_ligand_list]
     assert ax_formulas == ['H2O', 'CO']
     eq_formulas = [lig.mol.make_formula(latex=False) for lig in eq_ligand_list]
-    assert sorted(eq_formulas) == sorted(['H2S', 'H3N', 'CHN', 'CH2O'])
+    assert eq_formulas == ['CH2O', 'CHN', 'H3N', 'H2S']
 
     assert ax_natoms_list == [3, 2]
-    eq_by_formula = sorted(zip(eq_formulas, eq_natoms_list, eq_con_int_list,
-                               eq_con_list), key=lambda x: x[0])
-    expected_eq = sorted([
-        ('H2S', 3, [0], [14]), ('H3N', 4, [0], [4]),
-        ('CHN', 3, [1], [18]), ('CH2O', 4, [1], [11]),
-    ], key=lambda x: x[0])
-    assert eq_by_formula == expected_eq
+    assert eq_natoms_list == [4, 3, 4, 3]
 
     assert ax_con_int_list == [[0], [0]]
+    assert eq_con_int_list == [[1], [1], [0], [0]]
     assert ax_con_list == [[1], [8]]
+    assert eq_con_list == [[11], [18], [4], [14]]
 
 
 def test_triple_bidentate(resource_path_root):


### PR DESCRIPTION
…parison

Equatorial order is deterministic via canonical (formula, con) sort and trans reorder in ligand_assign_consistent. Simplify test_six_monodentate to assert that exact order instead of sorted/eq_by_formula logic.