### PR TITLE
Fix enhanced CLI explicit-donor handling and writeout tuple unpacking

### DIFF
--- a/molSimplify/__main__.py
+++ b/molSimplify/__main__.py
@@ -268,12 +268,14 @@ def run_build_complex(args):
     fixed_ligand_list = []
     pydentate_bool = pargs.pydentate
     if pydentate_bool:
-        from pydentate import pydentate_lite
+        pydentate_lite = None
         i = 0
         for ligand in ligand_list:
             if ligand[1] is None:
                 print(f"Missing coordinating atoms for ligand {ligands[i]}. \n Using pydentate prediction...")
                 try:
+                    if pydentate_lite is None:
+                        from pydentate import pydentate_lite
                     pydentate_results = pydentate_lite.pydentate_lite(ligands[i])
                     catoms = pydentate_results[1]
                     from molSimplify.Classes import mol2D
@@ -357,7 +359,7 @@ def run_build_complex(args):
         for length in ANN_bondl:
             bondl.append(length[1])
 
-    mol = enforce_metal_ligand_distances_and_optimize(mol, bondl, backbone_core_indices)
+    mol, _, _ = enforce_metal_ligand_distances_and_optimize(mol, bondl, backbone_core_indices)
 
     # -------------------- auto-build run name --------------------
     import re, hashlib

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,8 @@
 import pytest
+import sys
+import types
+import builtins
+import matplotlib.pyplot as plt
 from molSimplify.__main__ import main
 
 
@@ -11,3 +15,56 @@ def test_help_no_error():
     with pytest.raises(SystemExit) as exc_info:
         main(args=["--help"])
     #assert exc_info.value.code == 0
+
+
+def test_main_does_not_import_pydentate_with_explicit_usercatoms(monkeypatch, tmp_path):
+    class DummyMol:
+        def writexyz(self, path):
+            with open(path, "w") as handle:
+                handle.write("dummy xyz\n")
+
+        def writemol2_bodict(self, ignore_dummy_atoms=False, write_bond_orders=True, return_string=False, output_file=None):
+            with open(output_file, "w") as handle:
+                handle.write("dummy mol2\n")
+
+    class DummyFig:
+        def savefig(self, path, dpi=300):
+            with open(path, "w") as handle:
+                handle.write("dummy fig\n")
+
+    fake_enhanced = types.ModuleType("molSimplify.Scripts.enhanced_structgen")
+    fake_enhanced.create_ligand_list = lambda userligand_list, usercatoms_list=None, occupancy_list=None, isomer_list=None: [
+        ("lig", [0, 7], 3, None)
+    ]
+    fake_enhanced.generate_complex = lambda *args, **kwargs: (DummyMol(), [], {}, DummyFig(), [], [])
+    fake_enhanced.enhanced_init_ANN = lambda *args, **kwargs: None
+    fake_enhanced.enforce_metal_ligand_distances_and_optimize = (
+        lambda mol, bondl, backbone_core_indices: (mol, None, None)
+    )
+
+    fake_functionality = types.ModuleType("molSimplify.Scripts.enhanced_structgen_functionality")
+    fake_functionality.check_badjob = lambda mol: (False, True)
+
+    monkeypatch.setitem(sys.modules, "molSimplify.Scripts.enhanced_structgen", fake_enhanced)
+    monkeypatch.setitem(sys.modules, "molSimplify.Scripts.enhanced_structgen_functionality", fake_functionality)
+    monkeypatch.setattr(plt, "close", lambda *args, **kwargs: None)
+
+    real_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "pydentate":
+            raise AssertionError("pydentate should not be imported when explicit usercatoms are provided")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", guarded_import)
+
+    main(args=[
+        "--ligand", "NCCCOCCN",
+        "--usercatoms", "[0,7]",
+        "--occupancy", "3",
+        "--metal", "Fe",
+        "--ox", "2",
+        "--spin", "1",
+        "--geometry", "octahedral",
+        "--run-dir", str(tmp_path),
+    ])


### PR DESCRIPTION
`run_build_complex()` imported `pydentate` before checking whether any ligand was actually missing coordinating atoms. That made commands with explicit `--usercatoms` fail in environments where `pydentate` was not installed, even though donor prediction was not needed for the run.

After fixing that, the same enhanced CLI path hit a second bug: it overwrote `mol` with the full return value of `enforce_metal_ligand_distances_and_optimize(...)`, which returns a tuple. The later `mol.writexyz(...)` call then failed with:

```text
AttributeError: 'tuple' object has no attribute 'writexyz'
```

This patch defers the `pydentate` import until it is actually needed, unpacks the return value of `enforce_metal_ligand_distances_and_optimize(...)` before writeout, and adds a CLI regression test for the explicit `--usercatoms` path.

## Repro before

```bash
python -m molSimplify \
  --ligand NCCCOCCN \
  --usercatoms '[0,7]' \
  --occupancy 3 \
  --metal Fe \
  --ox 2 \
  --spin 1 \
  --geometry octahedral \
  --run-dir /tmp/molsimplify-cli-probe-repro
```

In an environment without `pydentate`, this failed immediately with:

```text
ModuleNotFoundError: No module named 'pydentate'
```

After the lazy-import change, the same command progressed to the next bug in the same CLI path:

```text
AttributeError: 'tuple' object has no attribute 'writexyz'
```

With both fixes in place, the command completes and writes the expected output files.

## Test

```bash
conda run -n materials-cli-molsimplify python -m pytest -q tests/test_cli.py
```

```text
2 passed
```
